### PR TITLE
Convert group times to PyCon time, to match session times

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,9 +16,9 @@ jobs:
         os: [windows-latest, macOS-latest]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node_version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node_version }}
     - name: Install Dependencies

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,7 @@
 
 name: Install Dependencies, Lint, Build and Test
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,6 @@ plugins/ios.json
 $RECYCLE.BIN/
 
 .DS_Store
+capacitor.config.json
 Thumbs.db
 UserInterfaceState.xcuserstate

--- a/src/app/providers/conference-data.ts
+++ b/src/app/providers/conference-data.ts
@@ -134,8 +134,8 @@ export class ConferenceData {
 
       this.data.sessions.push(session);
 
-      var day = start.toISOString().split('T')[0];
-      var group = start.toLocaleTimeString([], {hour: 'numeric', minute:'2-digit'}).toLowerCase();
+      let day = start.toISOString().split('T')[0];
+      let group = start.toLocaleTimeString([], {timeZone: "MST7MDT", hour: 'numeric', minute:'2-digit'}).toLowerCase();
 
       const scheduleDay = this.data.schedule.find(
         (d: any) => d.date === day


### PR DESCRIPTION
Ned's keynote is at 9:30 PyCon time: https://us.pycon.org/2023/schedule/talks/

# Before

I'm in Helsinki/EEST, 9 hours ahead of PyCon/Salt Lake City/MDT.

It shows SLC time for the keynote (9:30 – 10:10) but my local time for the group (Fri - 18:00):

![image](https://user-images.githubusercontent.com/1324225/230417876-71763a94-24a0-4972-b488-ccbbd7685aee.png)

# Fix

Let's set the same `timeZone: "MST7MDT"` option when converting the group time, as we do for the session start and end times:

https://github.com/psf/pycon-us-mobile/blob/331654a2a46e4ddd467b9c5e03d2a5e54d95d555/src/app/providers/conference-data.ts#L107-L108

# After

![image](https://user-images.githubusercontent.com/1324225/230419269-f3e92525-1fa1-45bd-8df0-745d30976148.png)

# Also

Bump GitHub Actions, run CI for pushes as well so contributors can confirm it passes before opening PRs.
