### PR TITLE
feat: persist schedule filters

### DIFF
--- a/src/app/pages/schedule-filter/schedule-filter.ts
+++ b/src/app/pages/schedule-filter/schedule-filter.ts
@@ -1,8 +1,9 @@
 import { Component } from '@angular/core';
-import { Config, ModalController, NavParams } from '@ionic/angular';
+import { Config, ModalController } from '@ionic/angular';
 
 import { ConferenceData } from '../../providers/conference-data';
 import { LiveUpdateService } from '../../providers/live-update.service';
+import { UserData } from '../../providers/user-data';
 
 
 @Component({
@@ -19,15 +20,15 @@ export class ScheduleFilterPage {
     public confData: ConferenceData,
     private config: Config,
     public modalCtrl: ModalController,
-    public navParams: NavParams,
     public liveUpdateService: LiveUpdateService,
+    private userData: UserData,
   ) { }
 
-  ionViewWillEnter() {
+  async ionViewWillEnter() {
     this.ios = this.config.get('mode') === `ios`;
 
-    // passed in array of track names that should be excluded (unchecked)
-    const excludedTrackNames = this.navParams.get('excludedTracks');
+    // Stored array of track names that should be excluded (unchecked)
+    const excludedTrackNames = await this.userData.getScheduleFilters();
 
     this.confData.getTracks().subscribe((tracks: any[]) => {
       tracks.forEach(track => {
@@ -51,6 +52,8 @@ export class ScheduleFilterPage {
     // Pass back a new array of track names to exclude
     const excludedTrackNames = this.tracks.filter(c => !c.isChecked).map(c => c.name);
     this.dismiss(excludedTrackNames);
+    // Save in local storage
+    this.userData.setScheduleFilters(excludedTrackNames);
   }
 
   dismiss(data?: any) {

--- a/src/app/providers/user-data.ts
+++ b/src/app/providers/user-data.ts
@@ -163,4 +163,15 @@ export class UserData {
       return value;
     });
   }
+
+  getScheduleFilters(): Promise<Array<string>> {
+    return this.storage.get('scheduleFilters').then((value) => {
+      // If there are none, return an empty array
+      return value || [];
+    });
+  }
+
+  setScheduleFilters(filters: any) {
+    this.storage.set('scheduleFilters', filters);
+  }
 }


### PR DESCRIPTION
Instead of using parameters passed from the navigation, persist in storage and load on subsequent page loads.

Refs: #35