### PR TITLE
Finalize #35

### DIFF
--- a/src/app/pages/schedule/schedule.html
+++ b/src/app/pages/schedule/schedule.html
@@ -66,6 +66,12 @@
     </ion-toolbar>
   </ion-header>
 
+  <ion-list #scheduleList [hidden]="shownSessions !== 0">
+    <ion-item>
+      <ion-text color="medium">No sessions found that match your current filters</ion-text>
+    </ion-item>
+  </ion-list>
+
   <ion-list #scheduleList [hidden]="shownSessions === 0">
     <ion-item-group *ngFor="let group of groups" [hidden]="group.hide">
       <ion-item-divider sticky>

--- a/src/app/pages/schedule/schedule.ts
+++ b/src/app/pages/schedule/schedule.ts
@@ -46,6 +46,9 @@ export class SchedulePage implements OnInit {
 
   ngOnInit() {
     this.ios = this.config.get('mode') === 'ios';
+    this.user.getScheduleFilters().then(filters => {
+      this.excludeTracks = filters;
+    });
 
     this.route.params.subscribe(routeParams => {
       this.reloadSchedule();


### PR DESCRIPTION
load schedule filters on app start, add helpful note for why nothing is showing.

closes #35