### PR TITLE
fix: prefer to compare array length

### DIFF
--- a/src/app/pages/schedule/schedule.ts
+++ b/src/app/pages/schedule/schedule.ts
@@ -57,7 +57,7 @@ export class SchedulePage implements OnInit {
       console.log(data)
       var currDay = data.filter(d => d.date === this.currentTime.toISOString().split("T")[0]);
       console.log(currDay)
-      if (currDay !== []) {
+      if (currDay.length > 0) {
         this.dayIndex = currDay[0].index;
       }
     });


### PR DESCRIPTION
The condition is likely to always return true, since JS compares objects by reference, not value.

```js
> [] == []
false
> [] !== []
true
> [].length > 0
false
```