### PR TITLE
fix: add border around speaker cards

### DIFF
--- a/src/app/pages/speaker-list/speaker-list.scss
+++ b/src/app/pages/speaker-list/speaker-list.scss
@@ -1,6 +1,8 @@
 .speaker-card {
   display: flex;
   flex-direction: column;
+  // add a border around the card to make it stand out
+  border: 1px solid var(--ion-color-step-150, #d7d8da);
 }
 
 /* Due to the fact the cards are inside of columns the margins don't overlap


### PR DESCRIPTION
In dark mode, these are a little hard to see.

Fixes #3

Emulating an iPhone 8, before and after:

<img width="359" alt="Screenshot 2023-04-20 at 19 26 39" src="https://user-images.githubusercontent.com/529516/233519231-f50ac5c2-c8db-46c3-a671-31a93585a2ac.png"> <img width="355" alt="Screenshot 2023-04-20 at 19 26 49" src="https://user-images.githubusercontent.com/529516/233519236-83c4bf72-7590-4ea9-aa9b-239306cb2e9c.png">

