### PR TITLE
Reload schedule if we asynchronously change the day

### DIFF
--- a/src/app/pages/schedule/schedule.ts
+++ b/src/app/pages/schedule/schedule.ts
@@ -68,6 +68,7 @@ export class SchedulePage implements OnInit, OnDestroy {
       console.log(currDay)
       if (currDay.length > 0) {
         this.dayIndex = currDay[0].index;
+        this.reloadSchedule();
       }
     });
 


### PR DESCRIPTION
Fixes #99.

(This probably could be reworked to await the result instead and only initialize once it has loaded instead of refreshing, but who's got time for that.)