### PR TITLE
Fix invisible back button on speaker page in light mode

### DIFF
--- a/src/app/pages/speaker-detail/speaker-detail.html
+++ b/src/app/pages/speaker-detail/speaker-detail.html
@@ -2,7 +2,7 @@
   <ion-header class="ion-no-border">
     <ion-toolbar>
       <ion-buttons slot="start">
-        <ion-back-button [defaultHref]="backHref"></ion-back-button>
+        <ion-back-button [defaultHref]="backHref" color="dark"></ion-back-button>
       </ion-buttons>
     </ion-toolbar>
   </ion-header>
@@ -23,16 +23,18 @@
     <h2>Presentations</h2>
     <ion-row>
       <ion-col *ngFor="let session of speaker?.sessions">
-      <ion-card class="presentation-card">
-        <ion-card-header>
-          <ion-item detail="false" lines="none" class="speaker-item" routerLink="/app/tabs/schedule/session/{{session.id}}">
-            <ion-label>
-              <h2>{{ session.track }}: {{session.name}}</h2>
-              <ion-text style="font-size: smaller;">{{session.day}} {{session.timeStart}} in {{session.location}}</ion-text>
-            </ion-label>
-          </ion-item>
-        </ion-card-header>
-      </ion-card>
+        <ion-card class="presentation-card">
+          <ion-card-header>
+            <ion-item detail="false" lines="none" class="speaker-item" routerLink="/app/tabs/schedule/session/{{session.id}}">
+              <ion-label>
+                <h2>{{ session.track }}: {{session.name}}</h2>
+                <ion-text style="font-size: smaller;">
+                  {{session.day}} {{session.timeStart}} in {{session.location}}
+                </ion-text>
+              </ion-label>
+            </ion-item>
+          </ion-card-header>
+        </ion-card>
       </ion-col>
     </ion-row>
   </div>


### PR DESCRIPTION
This fixes #98.

The back button on the speaker detail page was invisible in light mode
due to inheriting a white icon color on a white background.
This explicitly sets the back button color to ensure proper visibility
while keeping dark mode unaffected.