### PR TITLE
Fix text selectable

### DIFF
--- a/src/app/pages/speaker-detail/speaker-detail.html
+++ b/src/app/pages/speaker-detail/speaker-detail.html
@@ -2,7 +2,7 @@
   <ion-header class="ion-no-border">
     <ion-toolbar>
       <ion-buttons slot="start">
-        <ion-back-button [defaultHref]="backHref"></ion-back-button>
+        <ion-back-button [defaultHref]="backHref" color="dark"></ion-back-button>
       </ion-buttons>
     </ion-toolbar>
   </ion-header>
@@ -23,16 +23,18 @@
     <h2>Presentations</h2>
     <ion-row>
       <ion-col *ngFor="let session of speaker?.sessions">
-      <ion-card class="presentation-card">
-        <ion-card-header>
-          <ion-item detail="false" lines="none" class="speaker-item" routerLink="/app/tabs/schedule/session/{{session.id}}">
-            <ion-label>
-              <h2>{{ session.track }}: {{session.name}}</h2>
-              <ion-text style="font-size: smaller;">{{session.day}} {{session.timeStart}} in {{session.location}}</ion-text>
-            </ion-label>
-          </ion-item>
-        </ion-card-header>
-      </ion-card>
+        <ion-card class="presentation-card">
+          <ion-card-header>
+            <ion-item detail="false" lines="none" class="speaker-item" routerLink="/app/tabs/schedule/session/{{session.id}}">
+              <ion-label>
+                <h2>{{ session.track }}: {{session.name}}</h2>
+                <ion-text style="font-size: smaller;">
+                  {{session.day}} {{session.timeStart}} in {{session.location}}
+                </ion-text>
+              </ion-label>
+            </ion-item>
+          </ion-card-header>
+        </ion-card>
       </ion-col>
     </ion-row>
   </div>

--- a/src/global.scss
+++ b/src/global.scss
@@ -33,3 +33,18 @@
  */
 
 @import "./app/app.scss";
+
+/* Allow text selection for content text */
+ion-content p,
+ion-content h1,
+ion-content h2,
+ion-content h3,
+ion-content h4,
+ion-content h5,
+ion-content h6,
+ion-content ion-text,
+ion-content ion-label {
+  user-select: text;
+  -webkit-user-select: text;
+}
+


### PR DESCRIPTION
This change makes readable text in the app selectable so users can copy
speaker names, bios, session titles, and other content.

The change is scoped to content text only and does not affect navigation
or interactive UI elements.
