### PR TITLE
Style welcome page to match 2026 branding

### DIFF
--- a/src/app/pages/tutorial/tutorial.html
+++ b/src/app/pages/tutorial/tutorial.html
@@ -10,9 +10,9 @@
          Welcome to
          <b>PyCon US 2026</b>
        </h2>
-       <ion-button fill="solid" (click)="startApp()">
+       <button class="continue-btn" (click)="startApp()">
          Continue
-         <ion-icon slot="end" name="arrow-forward"></ion-icon>
-       </ion-button>
+         <ion-icon name="arrow-forward"></ion-icon>
+       </button>
    </div>
 </ion-content>

--- a/src/app/pages/tutorial/tutorial.scss
+++ b/src/app/pages/tutorial/tutorial.scss
@@ -1,3 +1,7 @@
+:host {
+  --ion-background-color: #680579;
+}
+
 ion-toolbar {
   --background: transparent;
   --border-color: transparent;
@@ -5,6 +9,7 @@ ion-toolbar {
 
 .slide-title {
   margin-top: 2.8rem;
+  color: #ffffff;
 }
 
 .slide-container {
@@ -16,13 +21,35 @@ ion-toolbar {
 
 .slide-image {
   max-height: 50% !important;
-  max-width: 80% !important;
+  width: 100% !important;
+  max-width: 100% !important;
   margin: 5vh 0;
   pointer-events: none;
 }
 
 b {
   font-weight: 500;
+}
+
+.continue-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5ch;
+  padding: 0.75em 1.5em;
+  border: 1.5px solid rgba(255, 255, 255, 0.4);
+  border-radius: 0.5em;
+  background-color: #ffffff;
+  color: #101136;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: 0px 0px 18px 0px rgba(255, 192, 203, 0.5);
+  transition: all 0.2s;
+
+  ion-icon {
+    font-size: 1.1em;
+  }
 }
 
 p {


### PR DESCRIPTION
## Summary
- Set page background to PyCon purple (`#680579` / `--color-accent-1`)
- Make splash image full-width instead of 80%
- White title text for contrast
- Restyle Continue button to match pycon-site button styles (white bg, pink glow, rounded)

Resolves: PYC-80

## Test plan
- [x] Reset simulator (Erase All Content and Settings) to see welcome screen
- [x] Verify background color matches splash image seamlessly
- [x] Verify button style looks clean on purple background

=
<img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/c86696d8-400e-4684-a8a9-b40474eb14e3" />
