### PR TITLE
Filter out empty track names from session filter

### DIFF
--- a/src/app/pages/schedule-filter/schedule-filter.ts
+++ b/src/app/pages/schedule-filter/schedule-filter.ts
@@ -31,7 +31,7 @@ export class ScheduleFilterPage {
     const excludedTrackNames = await this.userData.getScheduleFilters();
 
     this.confData.getTracks().subscribe((tracks: any[]) => {
-      tracks.forEach(track => {
+      tracks.filter(track => track.name && track.name.trim()).forEach(track => {
         this.tracks.push({
           name: track.name,
           icon: track.icon,


### PR DESCRIPTION
## Summary
- Filter out tracks with empty or whitespace-only names before rendering in the filter modal
- Fixes the blank checkbox entry at the bottom of the filter list

Resolves: PYC-85

## Test plan
- [x] Open schedule filter — no blank entries at the bottom
- [x] All valid tracks still appear and function correctly

<img width="415" height="520" alt="image" src="https://github.com/user-attachments/assets/1fe7bd86-258e-4464-a5ff-aa4bc24fc417" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)