### PR TITLE
Format track names for display

### DIFF
--- a/src/app/pages/schedule-filter/schedule-filter.html
+++ b/src/app/pages/schedule-filter/schedule-filter.html
@@ -21,7 +21,7 @@
 
     <ion-item *ngFor="let track of tracks" [attr.track]="track.name | lowercase">
       <ion-icon *ngIf="ios" slot="start" [name]="track.icon" color="medium"></ion-icon>
-      <ion-label>{{track.name}}</ion-label>
+      <ion-label>{{track.name | trackName}}</ion-label>
       <ion-checkbox [(ngModel)]="track.isChecked"></ion-checkbox>
     </ion-item>
 

--- a/src/app/pages/schedule-list/schedule-list.module.ts
+++ b/src/app/pages/schedule-list/schedule-list.module.ts
@@ -7,13 +7,15 @@ import { IonicModule } from '@ionic/angular';
 import { ScheduleListPageRoutingModule } from './schedule-list-routing.module';
 
 import { ScheduleListPage } from './schedule-list.page';
+import { PipesModule } from '../../pipes/pipes.module';
 
 @NgModule({
   imports: [
     CommonModule,
     FormsModule,
     IonicModule,
-    ScheduleListPageRoutingModule
+    ScheduleListPageRoutingModule,
+    PipesModule
   ],
   declarations: [ScheduleListPage]
 })

--- a/src/app/pages/schedule-list/schedule-list.page.html
+++ b/src/app/pages/schedule-list/schedule-list.page.html
@@ -37,7 +37,7 @@
                   {{session.name}}
               </ion-card-title>
               <ion-card-subtitle>
-                  <b>{{session.track}}</b>: {{session.day}} {{session.timeStart}} &mdash; {{session.timeEnd}}: {{session.location}}
+                  <b>{{session.track | trackName}}</b>: {{session.day}} {{session.timeStart}} &mdash; {{session.timeEnd}}: {{session.location}}
               </ion-card-subtitle>
             </ion-card-header>
             <ion-card-content>

--- a/src/app/pages/schedule/schedule.html
+++ b/src/app/pages/schedule/schedule.html
@@ -85,7 +85,7 @@
           <ion-label>
             <h3>
               <ion-icon *ngIf="session.favorite" slot="icon-only" name="star"></ion-icon>
-              {{session.track}}: {{session.name}}
+              {{session.track | trackName}}: {{session.name}}
             </h3>
             <ion-text *ngIf="session.preRegistered" color="medium" ><p class="pre-registerd">Pre-registration required</p></ion-text>
             <p>

--- a/src/app/pages/schedule/schedule.module.ts
+++ b/src/app/pages/schedule/schedule.module.ts
@@ -7,13 +7,15 @@ import { SchedulePage } from './schedule';
 import { ScheduleFilterPage } from '../schedule-filter/schedule-filter';
 import { SchedulePageRoutingModule } from './schedule-routing.module';
 import { SessionOrderPipe } from '../../pipes/session-order.pipe';
+import { PipesModule } from '../../pipes/pipes.module';
 
 @NgModule({
     imports: [
         CommonModule,
         FormsModule,
         IonicModule,
-        SchedulePageRoutingModule
+        SchedulePageRoutingModule,
+        PipesModule
     ],
     declarations: [
         SchedulePage,

--- a/src/app/pages/speaker-detail/speaker-detail.html
+++ b/src/app/pages/speaker-detail/speaker-detail.html
@@ -27,7 +27,7 @@
         <ion-card-header>
           <ion-item detail="false" lines="none" class="speaker-item" routerLink="/app/tabs/schedule/session/{{session.id}}">
             <ion-label>
-              <h2>{{ session.track }}: {{session.name}}</h2>
+              <h2>{{ session.track | trackName }}: {{session.name}}</h2>
               <ion-text style="font-size: smaller;">{{session.day}} {{session.timeStart}} in {{session.location}}</ion-text>
             </ion-label>
           </ion-item>

--- a/src/app/pages/speaker-detail/speaker-detail.module.ts
+++ b/src/app/pages/speaker-detail/speaker-detail.module.ts
@@ -4,12 +4,14 @@ import { CommonModule } from '@angular/common';
 import { SpeakerDetailPage } from './speaker-detail';
 import { SpeakerDetailPageRoutingModule } from './speaker-detail-routing.module';
 import { IonicModule } from '@ionic/angular';
+import { PipesModule } from '../../pipes/pipes.module';
 
 @NgModule({
   imports: [
     CommonModule,
     IonicModule,
-    SpeakerDetailPageRoutingModule
+    SpeakerDetailPageRoutingModule,
+    PipesModule
   ],
   declarations: [
     SpeakerDetailPage,

--- a/src/app/pages/speaker-list/speaker-list.html
+++ b/src/app/pages/speaker-list/speaker-list.html
@@ -46,7 +46,7 @@
             <ion-list lines="none">
               <ion-item *ngFor="let session of speaker.sessions" detail="false" routerLink="/app/tabs/speakers/session/{{session.id}}">
                 <ion-label>
-                  <h3>{{session.track}}: {{session.name}}</h3>
+                  <h3>{{session.track | trackName}}: {{session.name}}</h3>
                   <ion-text style="font-size: smaller;">{{session.day}} {{session.timeStart}} in {{session.location}}</ion-text>
                 </ion-label>
               </ion-item>

--- a/src/app/pages/speaker-list/speaker-list.module.ts
+++ b/src/app/pages/speaker-list/speaker-list.module.ts
@@ -5,13 +5,15 @@ import { FormsModule } from '@angular/forms';
 
 import { SpeakerListPage } from './speaker-list';
 import { SpeakerListPageRoutingModule } from './speaker-list-routing.module';
+import { PipesModule } from '../../pipes/pipes.module';
 
 @NgModule({
   imports: [
     CommonModule,
     FormsModule,
     IonicModule,
-    SpeakerListPageRoutingModule
+    SpeakerListPageRoutingModule,
+    PipesModule
   ],
   declarations: [SpeakerListPage],
 })

--- a/src/app/pipes/pipes.module.ts
+++ b/src/app/pipes/pipes.module.ts
@@ -1,0 +1,8 @@
+import { NgModule } from '@angular/core';
+import { TrackNamePipe } from './track-name.pipe';
+
+@NgModule({
+  declarations: [TrackNamePipe],
+  exports: [TrackNamePipe]
+})
+export class PipesModule {}

--- a/src/app/pipes/track-name.pipe.ts
+++ b/src/app/pipes/track-name.pipe.ts
@@ -1,0 +1,17 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+const TRACK_DISPLAY_NAMES: Record<string, string> = {
+  'Ai': 'AI',
+  'Lightning-talks': 'Lightning Talks',
+};
+
+@Pipe({
+  name: 'trackName'
+})
+export class TrackNamePipe implements PipeTransform {
+  transform(value: string): string {
+    if (!value) return value;
+    if (TRACK_DISPLAY_NAMES[value]) return TRACK_DISPLAY_NAMES[value];
+    return value.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+  }
+}


### PR DESCRIPTION
## Summary
- New `trackName` pipe that transforms raw API track names into proper display names
  - "Ai" → "AI"
  - "Lightning-talks" → "Lightning Talks"
  - General: replaces hyphens with spaces, title cases words
- Shared `PipesModule` so the pipe can be used across multiple lazy-loaded modules
- Applied to: schedule, filter modal, speaker list, speaker detail, schedule list

Resolves: PYC-101

## Test plan
- [ ] Filter modal shows "Lightning Talks" not "Lightning-talks", "AI" not "Ai"
- [ ] Schedule list items show formatted track names
- [ ] Speaker detail shows formatted track names

🤖 Generated with [Claude Code](https://claude.com/claude-code)