### PR TITLE
Fix Open Spaces page title formatting

### DIFF
--- a/src/app/pages/schedule-list/schedule-list.page.html
+++ b/src/app/pages/schedule-list/schedule-list.page.html
@@ -4,7 +4,7 @@
       <ion-menu-button [color]="liveUpdateService.needsUpdate ? 'primary' : 'medium'"></ion-menu-button>
       <ion-badge *ngIf="liveUpdateService.needsUpdate" size=sm>1</ion-badge>
     </ion-buttons>
-    <ion-title *ngIf="!ios && !showSearchbar">{{trackName}}</ion-title>
+    <ion-title *ngIf="!ios && !showSearchbar">{{trackName | trackName}}</ion-title>
     <ion-searchbar #search *ngIf="showSearchbar" [debounce]="250" showCancelButton="always" [(ngModel)]="sessionQueryText" (ionClear)="resetSessions()" (ionCancel)="resetSessions()" (ionChange)="searchSessions()" (ionCancel)="showSearchbar = false" placeholder="Search"></ion-searchbar>
     <ion-buttons slot="end">
       <ion-button *ngIf="!ios && !showSearchbar" (click)="showSearchbar = true && focusButton()">
@@ -17,7 +17,7 @@
 <ion-content fullscreen="true">
   <ion-header collapse="condense">
     <ion-toolbar>
-      <ion-title size="large">{{trackName}}</ion-title>
+      <ion-title size="large">{{trackName | trackName}}</ion-title>
     </ion-toolbar>
 
     <ion-toolbar>


### PR DESCRIPTION
## Summary
- Apply `trackName` pipe to the schedule-list page title
- "open-spaces" now displays as "Open Spaces"

Resolves: PYC-91

## Test plan
- [x] Navigate to Open Spaces from side menu — title shows "Open Spaces"
<img width="366" height="168" alt="image" src="https://github.com/user-attachments/assets/49a32ed6-74b4-4e63-868a-3c6a05b3bb00" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)