### PR TITLE
Add menu buttons to Door Check and T-Shirt Redemption

### DIFF
--- a/src/app/pages/door-check/door-check.page.html
+++ b/src/app/pages/door-check/door-check.page.html
@@ -1,5 +1,8 @@
 <ion-header>
   <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-menu-button color="medium"></ion-menu-button>
+    </ion-buttons>
     <ion-title>Door Check</ion-title>
   </ion-toolbar>
 </ion-header>

--- a/src/app/pages/t-shirt-redemption/t-shirt-redemption.page.html
+++ b/src/app/pages/t-shirt-redemption/t-shirt-redemption.page.html
@@ -1,5 +1,8 @@
 <ion-header>
   <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-menu-button color="medium"></ion-menu-button>
+    </ion-buttons>
     <ion-title>T-Shirt Redemption</ion-title>
   </ion-toolbar>
 </ion-header>


### PR DESCRIPTION
## Summary
- Add `ion-menu-button` to Door Check and T-Shirt Redemption page headers
- Matches the navigation pattern used by all other side-menu pages

Resolves: PYC-97

## Test plan
- [x] Door Check page shows hamburger menu button
- [x] T-Shirt Redemption page shows hamburger menu button
- [x] Tapping menu button opens the side menu
<img width="345" height="53" alt="image" src="https://github.com/user-attachments/assets/c98c7fd8-1ec7-4d02-9a40-e248629e5d08" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)