### PR TITLE
Fix speaker image safe area and back button visibility

### DIFF
--- a/src/app/pages/speaker-detail/speaker-detail.html
+++ b/src/app/pages/speaker-detail/speaker-detail.html
@@ -1,12 +1,12 @@
-<ion-content class="speaker-detail">
-  <ion-header class="ion-no-border">
-    <ion-toolbar>
-      <ion-buttons slot="start">
-        <ion-back-button [defaultHref]="backHref"></ion-back-button>
-      </ion-buttons>
-    </ion-toolbar>
-  </ion-header>
+<ion-header class="ion-no-border">
+  <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-back-button [defaultHref]="backHref"></ion-back-button>
+    </ion-buttons>
+  </ion-toolbar>
+</ion-header>
 
+<ion-content class="speaker-detail">
   <div class="speaker-background">
     <img class="rounded speaker-image" [src]="speaker?.profilePic" [alt]="speaker?.name">
     <img class="rounded speaker-backbackground" src="/assets/img/speaker-background.png">

--- a/src/app/pages/speaker-detail/speaker-detail.scss
+++ b/src/app/pages/speaker-detail/speaker-detail.scss
@@ -3,20 +3,13 @@
  */
 
 ion-toolbar {
-  position: absolute;
-
-  top: 0;
-  left: 0;
-  right: 0;
-
   --background: transparent;
-  --color: white;
 }
 
 ion-toolbar ion-button,
 ion-toolbar ion-back-button,
 ion-toolbar ion-menu-button {
-  --color: white;
+  --color: var(--ion-color-primary);
 }
 
 .speaker-background {
@@ -24,15 +17,12 @@ ion-toolbar ion-menu-button {
 
   display: flex;
 
-  padding-top: var(--ion-safe-area-top);
-
   align-items: center;
   justify-content: center;
 
   flex-direction: column;
 
-  height: calc(250px + var(--ion-safe-area-top));
-  z-index: -3;
+  height: 250px;
 }
 
 img.rounded {
@@ -45,7 +35,6 @@ img.rounded {
   position: absolute;
   width: 45%;
   max-width: 12.5em;
-  margin-top: calc(-.5 * var(--ion-safe-area-top));
   z-index: -1;
 }
 
@@ -53,7 +42,6 @@ img.rounded {
   position: absolute;
   width: 57%;
   max-width: 15em;
-  margin-top: calc(-.5 * var(--ion-safe-area-top));
   z-index: -2;
 }
 


### PR DESCRIPTION
## Summary
- Move `ion-header` outside `ion-content` so the back button renders as a proper header
- Remove `position: absolute` toolbar and negative margins that pushed the speaker image into the Dynamic Island
- Fix back button color from white (invisible on white bg) to primary blue

Resolves: PYC-84
Related: PYC-86

## Test plan
- [x] Speaker detail page shows visible back button
- [x] Speaker image no longer overlaps Dynamic Island
- [x] Back button navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)