### PR TITLE
Add 'Search all days' button on empty schedule results

### DIFF
--- a/src/app/pages/schedule/schedule.html
+++ b/src/app/pages/schedule/schedule.html
@@ -70,6 +70,14 @@
     <ion-item>
       <ion-text color="medium">No sessions found that match your current filters</ion-text>
     </ion-item>
+    <ion-item *ngIf="queryText" lines="none" class="ion-text-center">
+      <ion-label>
+        <button class="search-all-btn" [class.exhausted]="searchedAllDays" [disabled]="searchedAllDays" (click)="searchAllDays()">
+          {{ searchedAllDays ? 'No results on any day' : 'Search all days' }}
+          <ion-icon [name]="searchedAllDays ? 'close-circle-outline' : 'calendar-outline'"></ion-icon>
+        </button>
+      </ion-label>
+    </ion-item>
   </ion-list>
 
   <ion-list #scheduleList [hidden]="shownSessions === 0">

--- a/src/app/pages/schedule/schedule.scss
+++ b/src/app/pages/schedule/schedule.scss
@@ -42,3 +42,33 @@ p .pre-registerd {
 ion-segment-button {
   min-width: auto;
 }
+
+.search-all-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5ch;
+  padding: 0.75em 1.5em;
+  border: 1.5px solid rgba(56, 128, 255, 0.3);
+  border-radius: 0.5em;
+  background-color: var(--ion-color-primary, #3880ff);
+  color: #ffffff;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: 0px 0px 18px 0px rgba(56, 128, 255, 0.3);
+  transition: all 0.2s;
+  margin-top: 0.5em;
+
+  ion-icon {
+    font-size: 1.1em;
+  }
+
+  &.exhausted {
+    background-color: var(--ion-color-medium, #92949c);
+    border-color: transparent;
+    box-shadow: none;
+    opacity: 0.7;
+    cursor: default;
+  }
+}

--- a/src/app/pages/schedule/schedule.ts
+++ b/src/app/pages/schedule/schedule.ts
@@ -31,6 +31,7 @@ export class SchedulePage implements OnInit, OnDestroy {
   groups: any = [];
   confDate: string;
   showSearchbar: boolean;
+  searchedAllDays: boolean = false;
   currentTime: Date;
   private favoritesSubscription: Subscription;
 
@@ -102,6 +103,8 @@ export class SchedulePage implements OnInit, OnDestroy {
   }
 
   updateSchedule() {
+    this.searchedAllDays = false;
+
     // Close any open sliding items when the schedule updates
     if (this.scheduleList) {
       this.scheduleList.closeSlidingItems();
@@ -142,6 +145,28 @@ export class SchedulePage implements OnInit, OnDestroy {
         loader.dismiss();
       });
     });
+  }
+
+  searchAllDays() {
+    let found = false;
+    let checked = 0;
+    for (let i = 0; i < this.days.length; i++) {
+      this.confData.getTimeline(String(i), this.queryText, this.excludeTracks, this.segment).subscribe((data: any) => {
+        checked++;
+        if (data.shownSessions > 0 && !found) {
+          found = true;
+          this.dayIndex = String(i);
+          this.shownSessions = data.shownSessions;
+          this.groups = data.groups;
+          this.searchedAllDays = false;
+          this.changeDetectorRef.detectChanges();
+        }
+        if (checked === this.days.length && !found) {
+          this.searchedAllDays = true;
+          this.changeDetectorRef.detectChanges();
+        }
+      });
+    }
   }
 
   async focusButton() {


### PR DESCRIPTION
## Summary
- Show a "Search all days" button when a schedule search returns no results on the current day
- Searches across all conference days and jumps to the first day with matches
- If no results on any day, button grays out and shows "No results on any day"
- Resets when the search query or day changes

## Test plan
- [x] Search for something that exists on a different day — button appears, tapping it finds results
- [x] Search for gibberish — button appears, tapping it shows "No results on any day" (grayed out)
- [x] Change search text — button resets back to "Search all days"

Resolves: PYC-82
<img width="431" height="266" alt="image" src="https://github.com/user-attachments/assets/4e849261-78bb-4aed-97a5-9c4c034f8b20" />
<img width="440" height="297" alt="image" src="https://github.com/user-attachments/assets/c3ecbeb7-6199-43f9-8bbe-bde6193f6a2a" />

<img width="439" height="252" alt="image" src="https://github.com/user-attachments/assets/28944d1a-c4f5-46d9-9450-96ef2e4cefa8" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)