### PR TITLE
Add visual track indicators to schedule list

### DIFF
--- a/src/app/pages/schedule/schedule.html
+++ b/src/app/pages/schedule/schedule.html
@@ -93,9 +93,10 @@
           <ion-label>
             <h3>
               <ion-icon *ngIf="session.favorite" slot="icon-only" name="star"></ion-icon>
-              {{session.track | trackName}}: {{session.name}}
+              {{session.name}}
             </h3>
-            <ion-text *ngIf="session.preRegistered" color="medium" ><p class="pre-registerd">Pre-registration required</p></ion-text>
+            <span class="track-badge" [attr.data-track]="session.track | lowercase">{{session.track | trackName}}</span>
+            <span *ngIf="session.preRegistered" class="track-badge prereg-badge">Pre-registration required</span>
             <p>
               {{session.timeStart}}<span *ngIf="session.timeStart !== session.timeEnd"> &mdash; {{session.timeEnd}}</span>: {{session.location}} <span *ngIf="session?.speakerNames">&mdash; {{session.speakerNames?.join(', ')}}</span>
             </p>

--- a/src/app/pages/schedule/schedule.scss
+++ b/src/app/pages/schedule/schedule.scss
@@ -14,23 +14,56 @@ ion-fab-button {
   --background-activated: var(--ion-color-step-250, #d9d9d9);
 }
 
-$categories: (
-  ionic: var(--ion-color-primary),
-  angular: #ac282b,
-  communication: #8e8d93,
-  tooling: #fe4c52,
-  services: #fd8b2d,
-  design: #fed035,
-  workshop: #69bb7b,
-  food: #3bc7c4,
-  documentation: #b16be3,
-  navigation: #6600cc
+$tracks: (
+  talk: #5833E9,
+  tutorial: #DD04D2,
+  keynote: #680579,
+  plenary: #630675,
+  break: #3A3A3A,
+  lightning-talks: #C05CA0,
+  security: #F19C0B,
+  ai: #10B57F,
+  charla: #527CB2,
+  poster: #D47454,
+  sponsor\ presentation: #FFD779,
+  open\ space: #6FCF97,
 );
 
-@each $track, $value in map-remove($categories) {
+@each $track, $color in $tracks {
   ion-item-sliding[track='#{$track}'] ion-label {
-    border-left: 2px solid $value;
+    border-left: 3px solid $color;
     padding-left: 10px;
+  }
+}
+
+.track-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  margin-right: 6px;
+  border-radius: 99px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  line-height: 1.4;
+  color: #ffffff;
+  background-color: var(--ion-color-medium, #92949c);
+
+  &[data-track='talk'] { background-color: #5833E9; }
+  &[data-track='tutorial'] { background-color: #DD04D2; }
+  &[data-track='keynote'] { background-color: #680579; }
+  &[data-track='plenary'] { background-color: #630675; }
+  &[data-track='break'] { background-color: #3A3A3A; }
+  &[data-track='lightning-talks'] { background-color: #C05CA0; }
+  &[data-track='security'] { background-color: #F19C0B; }
+  &[data-track='ai'] { background-color: #10B57F; }
+  &[data-track='charla'] { background-color: #527CB2; }
+  &[data-track='poster'] { background-color: #D47454; }
+  &[data-track='sponsor presentation'] { background-color: #B8860B; }
+  &[data-track='open space'] { background-color: #6FCF97; color: #1a1a1a; }
+
+  &.prereg-badge {
+    background-color: transparent;
+    color: var(--ion-color-danger, #eb445a);
+    border: 1px solid var(--ion-color-danger, #eb445a);
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace "Track: Title" format with session title + colored pill badge
- Add colored left border per track matching pycon-site schedule colors
- Pre-registration shown as outlined red "Pre-reg" badge
- Track colors sourced from pycon-site's `schedule.css` variables

Resolves: PYC-99

## Test plan
- [x] Each track has a distinct colored left border and pill badge
- [x] Pre-reg sessions show the "Pre-reg" outlined badge
- [x] Badge spacing looks clean with multiple badges
<img width="442" height="734" alt="image" src="https://github.com/user-attachments/assets/c1ba8156-a2d7-45b0-97e2-c049dde8cf0a" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)