### PR TITLE
Replace door check product dropdown with searchable list

### DIFF
--- a/src/app/pages/door-check/door-check.page.html
+++ b/src/app/pages/door-check/door-check.page.html
@@ -33,13 +33,21 @@
       </ion-select>
     </ion-item>
 
-    <ion-item *ngIf="!dirty">
-      <ion-select [(ngModel)]="product" interface="popover" [interfaceOptions]="{'cssClass': 'mycomponent-wider-popover'}" aria-label="products"  label="Product" placeholder="Product">
-        <div *ngFor="let product of display_products">
-          <ion-select-option [value]="product.id">{{product.name}}</ion-select-option>
-        </div>
-        <ion-select-option value="all">ALL</ion-select-option>
-      </ion-select>
+    <ion-item *ngIf="!dirty && display_products">
+      <ion-searchbar [(ngModel)]="productSearch" (ionInput)="filterProductList()" placeholder="Search sessions..." debounce="150"></ion-searchbar>
+    </ion-item>
+
+    <ion-item *ngIf="!dirty && display_products" lines="none" class="ion-no-padding">
+      <ion-list class="product-list">
+        <ion-item button (click)="selectProduct('all')" [color]="product === 'all' ? 'primary' : ''">
+          <ion-label><strong>ALL</strong></ion-label>
+          <ion-icon *ngIf="product === 'all'" slot="end" name="checkmark"></ion-icon>
+        </ion-item>
+        <ion-item *ngFor="let p of filtered_products" button (click)="selectProduct(p.id)" [color]="product === p.id ? 'primary' : ''">
+          <ion-label class="ion-text-wrap">{{p.name}}</ion-label>
+          <ion-icon *ngIf="product === p.id" slot="end" name="checkmark"></ion-icon>
+        </ion-item>
+      </ion-list>
     </ion-item>
 
     <ion-item *ngIf="category || product">
@@ -54,8 +62,8 @@
       </ion-card>
     </ion-item>
 
-    <ion-item *ngIf="!product">
-      <ion-text>Select a product to start scanning!</ion-text>
+    <ion-item *ngIf="!product && category">
+      <ion-text>Select a session to start scanning!</ion-text>
     </ion-item>
 
   </ion-list>

--- a/src/app/pages/door-check/door-check.page.scss
+++ b/src/app/pages/door-check/door-check.page.scss
@@ -24,3 +24,9 @@
   --width: 95%;
   --max-width: 400px;
 }
+
+.product-list {
+  width: 100%;
+  max-height: 300px;
+  overflow-y: auto;
+}

--- a/src/app/pages/door-check/door-check.page.ts
+++ b/src/app/pages/door-check/door-check.page.ts
@@ -34,6 +34,8 @@ export class DoorCheckPage implements OnInit, OnDestroy {
   redeemable_products: any = null;
   redeemable_categories: any = null;
   display_products: any = null;
+  filtered_products: any = null;
+  productSearch: string = '';
 
   product_attendees: Map<string, number>|null = null;
   inventory: Map<string, Map<number, number>>|null = null;
@@ -62,7 +64,24 @@ export class DoorCheckPage implements OnInit, OnDestroy {
   }
 
   refreshProducts() {
-    this.display_products = this.filterProducts().sort(function(a, b){if (a.name < b.name) return -1; if (a.name < b.name) return 1; return 0;});
+    this.display_products = this.filterProducts().sort(function(a, b){if (a.name < b.name) return -1; if (a.name > b.name) return 1; return 0;});
+    this.filtered_products = this.display_products;
+    this.productSearch = '';
+    this.product = null;
+    this.detectorRef.detectChanges();
+  }
+
+  filterProductList() {
+    if (!this.productSearch || !this.productSearch.trim()) {
+      this.filtered_products = this.display_products;
+    } else {
+      const q = this.productSearch.toLowerCase();
+      this.filtered_products = this.display_products.filter(p => p.name.toLowerCase().includes(q));
+    }
+  }
+
+  selectProduct(productId: any) {
+    this.product = productId;
     this.detectorRef.detectChanges();
   }
 


### PR DESCRIPTION
## Summary
- Replace `ion-select` popover with inline searchable list for session selection
- Search bar filters sessions by name in real-time
- Full session names visible (no truncation)
- Tap-to-select with checkmark indicator, "ALL" option at top
- Scrollable list capped at 300px height
- Fixed sort comparison bug

Resolves: PYC-95

## Test plan
- [x] Select a category — searchable list appears
- [x] Type to filter sessions
- [x] Tap a session — checkmark shows, "Scanning for..." card updates
- [x] "ALL" option works
- [x] Scanner starts correctly after selection
<img width="435" height="405" alt="image" src="https://github.com/user-attachments/assets/609f36d0-bfb5-4927-836e-c53edf1a3621" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)