### PR TITLE
Filter T-Shirt Redemption to only show shirt categories

### DIFF
--- a/src/app/pages/t-shirt-redemption/t-shirt-redemption.page.ts
+++ b/src/app/pages/t-shirt-redemption/t-shirt-redemption.page.ts
@@ -192,7 +192,9 @@ export class TShirtRedemptionPage implements OnInit, OnDestroy {
     this.pycon.fetchCheckInProducts().then((data) => {
       data.subscribe(redeemable => {
         this.redeemable_products = redeemable?.redeemable_products;
-        this.redeemable_categories = redeemable?.redeemable_categories;
+        this.redeemable_categories = redeemable?.redeemable_categories?.filter(
+          (cat: any) => cat.name?.toLowerCase().includes('shirt') || cat.name?.toLowerCase().includes('swag') || cat.name?.toLowerCase().includes('merch')
+        );
       })
     })
   }


### PR DESCRIPTION
## Summary
- Filter redeemable categories on T-Shirt Redemption page to only show shirt/swag/merch categories
- Matches by name containing "shirt", "swag", or "merch" (case-insensitive)
- Filters out unrelated categories like Tutorials and Auction
- Matches: Conference T-Shirts (id:4), Charlas T-Shirts (id:5), PyLadies T-Shirts (id:10)

Resolves: PYC-96

## Test plan
- [ ] T-Shirt Redemption only shows shirt categories in dropdown
- [ ] Tutorials and Auction no longer appear
- [ ] Scanner still works after selecting a shirt category

🤖 Generated with [Claude Code](https://claude.com/claude-code)