### PR TITLE
Add track badges to speaker and session detail pages

### DIFF
--- a/src/app/pages/schedule-list/schedule-list.page.html
+++ b/src/app/pages/schedule-list/schedule-list.page.html
@@ -37,7 +37,8 @@
                   {{session.name}}
               </ion-card-title>
               <ion-card-subtitle>
-                  <b>{{session.track | trackName}}</b>: {{session.day}} {{session.timeStart}} &mdash; {{session.timeEnd}}: {{session.location}}
+                  <span class="track-badge" [attr.data-track]="session.track | lowercase">{{session.track | trackName}}</span>
+                  {{session.day}} {{session.timeStart}} &mdash; {{session.timeEnd}}: {{session.location}}
               </ion-card-subtitle>
             </ion-card-header>
             <ion-card-content>

--- a/src/app/pages/schedule/schedule.scss
+++ b/src/app/pages/schedule/schedule.scss
@@ -36,47 +36,6 @@ $tracks: (
   }
 }
 
-.track-badge {
-  display: inline-block;
-  padding: 2px 8px;
-  margin-right: 6px;
-  border-radius: 99px;
-  font-size: 0.7rem;
-  font-weight: 600;
-  line-height: 1.4;
-  color: #ffffff;
-  background-color: var(--ion-color-medium, #92949c);
-
-  &[data-track='talk'] { background-color: #5833E9; }
-  &[data-track='tutorial'] { background-color: #DD04D2; }
-  &[data-track='keynote'] { background-color: #680579; }
-  &[data-track='plenary'] { background-color: #630675; }
-  &[data-track='break'] { background-color: #3A3A3A; }
-  &[data-track='lightning-talks'] { background-color: #C05CA0; }
-  &[data-track='security'] { background-color: #F19C0B; }
-  &[data-track='ai'] { background-color: #10B57F; }
-  &[data-track='charla'] { background-color: #527CB2; }
-  &[data-track='poster'] { background-color: #D47454; }
-  &[data-track='sponsor presentation'] { background-color: #B8860B; }
-  &[data-track='open space'] { background-color: #6FCF97; color: #1a1a1a; }
-
-  &.spanish-badge {
-    background-color: #DD04D2;
-    color: #ffffff;
-  }
-
-  &.prereg-badge {
-    background-color: transparent;
-    color: var(--ion-color-danger, #eb445a);
-    border: 1px solid var(--ion-color-danger, #eb445a);
-  }
-}
-
-p .pre-registerd {
-  font-size: smaller;
-  font-style: italic;
-}
-
 ion-segment-button {
   min-width: auto;
 }

--- a/src/app/pages/session-detail/session-detail.html
+++ b/src/app/pages/session-detail/session-detail.html
@@ -15,7 +15,12 @@
 <ion-content>
   <div *ngIf="session" class="ion-padding">
     <h1>{{session.name}}</h1>
-    <span *ngFor="let track of session?.tracks" [class]="'session-track-'+track.toLowerCase()">{{track}}</span>
+    <span *ngFor="let track of session?.tracks" class="track-badge" [attr.data-track]="track | lowercase">{{track | trackName : 'long'}}</span>
+    <span *ngFor="let track of session?.tracks">
+      <span *ngIf="(track | lowercase) === 'ai' || (track | lowercase) === 'security'" class="track-badge new-badge">New track!</span>
+    </span>
+    <span *ngIf="session?.isSpanish" class="track-badge spanish-badge">En Español</span>
+    <span *ngIf="session?.preRegistered" class="track-badge prereg-badge">Pre-registration required</span>
     <div [innerHtml]="session?.description">
     </div>
     <ion-text color="medium">

--- a/src/app/pages/session-detail/session-detail.module.ts
+++ b/src/app/pages/session-detail/session-detail.module.ts
@@ -4,12 +4,14 @@ import { CommonModule } from '@angular/common';
 import { SessionDetailPage } from './session-detail';
 import { SessionDetailPageRoutingModule } from './session-detail-routing.module';
 import { IonicModule } from '@ionic/angular';
+import { PipesModule } from '../../pipes/pipes.module';
 
 @NgModule({
   imports: [
     CommonModule,
     IonicModule,
-    SessionDetailPageRoutingModule
+    SessionDetailPageRoutingModule,
+    PipesModule
   ],
   declarations: [
     SessionDetailPage,

--- a/src/app/pages/speaker-detail/speaker-detail.html
+++ b/src/app/pages/speaker-detail/speaker-detail.html
@@ -27,7 +27,8 @@
         <ion-card-header>
           <ion-item detail="false" lines="none" class="speaker-item" routerLink="/app/tabs/schedule/session/{{session.id}}">
             <ion-label>
-              <h2>{{ session.track | trackName }}: {{session.name}}</h2>
+              <h2>{{session.name}}</h2>
+              <span class="track-badge" [attr.data-track]="session.track | lowercase">{{session.track | trackName}}</span>
               <ion-text style="font-size: smaller;">{{session.day}} {{session.timeStart}} in {{session.location}}</ion-text>
             </ion-label>
           </ion-item>

--- a/src/app/pages/speaker-list/speaker-list.html
+++ b/src/app/pages/speaker-list/speaker-list.html
@@ -46,7 +46,8 @@
             <ion-list lines="none">
               <ion-item *ngFor="let session of speaker.sessions" detail="false" routerLink="/app/tabs/speakers/session/{{session.id}}">
                 <ion-label>
-                  <h3>{{session.track | trackName}}: {{session.name}}</h3>
+                  <h3>{{session.name}}</h3>
+                  <span class="track-badge" [attr.data-track]="session.track | lowercase">{{session.track | trackName}}</span>
                   <ion-text style="font-size: smaller;">{{session.day}} {{session.timeStart}} in {{session.location}}</ion-text>
                 </ion-label>
               </ion-item>

--- a/src/app/pipes/track-name.pipe.ts
+++ b/src/app/pipes/track-name.pipe.ts
@@ -5,12 +5,18 @@ const TRACK_DISPLAY_NAMES: Record<string, string> = {
   'Lightning-talks': 'Lightning Talks',
 };
 
+const TRACK_LONG_NAMES: Record<string, string> = {
+  'Ai': 'The Future of AI with Python',
+  'Security': 'Trailblazing Python Security',
+};
+
 @Pipe({
   name: 'trackName'
 })
 export class TrackNamePipe implements PipeTransform {
-  transform(value: string): string {
+  transform(value: string, format: string = 'short'): string {
     if (!value) return value;
+    if (format === 'long' && TRACK_LONG_NAMES[value]) return TRACK_LONG_NAMES[value];
     if (TRACK_DISPLAY_NAMES[value]) return TRACK_DISPLAY_NAMES[value];
     return value.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
   }

--- a/src/global.scss
+++ b/src/global.scss
@@ -33,3 +33,47 @@
  */
 
 @import "./app/app.scss";
+
+/*
+ * Track badges — shared across schedule, speaker, and session pages
+ */
+.track-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  margin-right: 6px;
+  border-radius: 99px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  line-height: 1.4;
+  color: #ffffff;
+  background-color: var(--ion-color-medium, #92949c);
+
+  &[data-track='talk'] { background-color: #5833E9; }
+  &[data-track='tutorial'] { background-color: #DD04D2; }
+  &[data-track='keynote'] { background-color: #680579; }
+  &[data-track='plenary'] { background-color: #630675; }
+  &[data-track='break'] { background-color: #3A3A3A; }
+  &[data-track='lightning-talks'] { background-color: #C05CA0; }
+  &[data-track='security'] { background-color: #F19C0B; }
+  &[data-track='ai'] { background-color: #10B57F; }
+  &[data-track='charla'] { background-color: #527CB2; }
+  &[data-track='poster'] { background-color: #D47454; }
+  &[data-track='sponsor presentation'] { background-color: #B8860B; }
+  &[data-track='open space'] { background-color: #6FCF97; color: #1a1a1a; }
+
+  &.new-badge {
+    background-color: #680579;
+    color: #ffffff;
+  }
+
+  &.spanish-badge {
+    background-color: #DD04D2;
+    color: #ffffff;
+  }
+
+  &.prereg-badge {
+    background-color: transparent;
+    color: var(--ion-color-danger, #eb445a);
+    border: 1px solid var(--ion-color-danger, #eb445a);
+  }
+}


### PR DESCRIPTION
## Summary
- Move track badge CSS from `schedule.scss` to `global.scss` for reuse
- Replace "Track: Title" format with title + colored pill badge on:
  - Speaker list (session cards)
  - Speaker detail (presentations)
  - Schedule list (track view)
- Consistent badge styling across all pages

Resolves: PYC-103

## Test plan
- [x] Speaker list shows session badges instead of "Track: Title"
- [ ] Speaker detail presentations show badges
- [ ] Schedule list (track views) show badges
- [ ] Schedule page badges still work (styles moved to global)

🤖 Generated with [Claude Code](https://claude.com/claude-code)