### PR TITLE
Add login/account, map, and scanner to bottom tab bar

### DIFF
--- a/src/app/pages/tabs-page/tabs-page-routing.module.ts
+++ b/src/app/pages/tabs-page/tabs-page-routing.module.ts
@@ -130,6 +130,14 @@ const routes: Routes = [
         ]
       },
       {
+        path: 'account',
+        loadChildren: () => import('../account/account.module').then(m => m.AccountModule)
+      },
+      {
+        path: 'login',
+        loadChildren: () => import('../login/login.module').then(m => m.LoginModule)
+      },
+      {
         path: '',
         redirectTo: '/app/tabs/schedule',
         pathMatch: 'full'

--- a/src/app/pages/tabs-page/tabs-page.html
+++ b/src/app/pages/tabs-page/tabs-page.html
@@ -4,20 +4,40 @@
     <span style="padding-left: 1em; font-size: smaller;"> {{BannerSponsor.name}} is a {{BannerSponsor.level}}<br> Sponsor of PyCon US 2026</span>
   </ion-tab-bar>
 
-  <ion-tab-bar slot="bottom">
-    <ion-tab-button tab="schedule">
-      <ion-icon name="calendar"></ion-icon>
-      <ion-label>Schedule</ion-label>
-    </ion-tab-button>
-
+  <ion-tab-bar slot="bottom" class="pycon-tab-bar">
     <ion-tab-button tab="speakers">
       <ion-icon name="people"></ion-icon>
       <ion-label>Speakers</ion-label>
     </ion-tab-button>
 
-    <ion-tab-button *ngIf="hasLeadRetrieval" tab="lead-retrieval">
+    <ion-tab-button tab="conference-map">
+      <ion-icon name="map"></ion-icon>
+      <ion-label>Map</ion-label>
+    </ion-tab-button>
+
+    <ion-tab-button tab="schedule">
+      <ion-icon name="calendar"></ion-icon>
+      <ion-label>Schedule</ion-label>
+    </ion-tab-button>
+
+    <ion-tab-button *ngIf="hasDoorCheck" (click)="openStaffTools($event)">
+      <ion-icon name="scan"></ion-icon>
+      <ion-label>Scanner</ion-label>
+    </ion-tab-button>
+
+    <ion-tab-button *ngIf="hasLeadRetrieval && !hasDoorCheck" tab="lead-retrieval">
       <ion-icon name="qr-code"></ion-icon>
       <ion-label>Scanner</ion-label>
+    </ion-tab-button>
+
+    <ion-tab-button *ngIf="loggedIn" tab="account">
+      <ion-icon name="person-circle"></ion-icon>
+      <ion-label>Account</ion-label>
+    </ion-tab-button>
+
+    <ion-tab-button *ngIf="!loggedIn" tab="login">
+      <ion-icon name="log-in"></ion-icon>
+      <ion-label>Login</ion-label>
     </ion-tab-button>
 
   </ion-tab-bar>

--- a/src/app/pages/tabs-page/tabs-page.scss
+++ b/src/app/pages/tabs-page/tabs-page.scss
@@ -9,3 +9,4 @@
   border-radius: .25em;
   padding: .25em;
 }
+

--- a/src/app/pages/tabs-page/tabs-page.ts
+++ b/src/app/pages/tabs-page/tabs-page.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit } from '@angular/core';
+import { ActionSheetController } from '@ionic/angular';
+import { Router } from '@angular/router';
 
 import { ConferenceData } from '../../providers/conference-data';
 import { UserData } from '../../providers/user-data';
@@ -12,17 +14,61 @@ export class TabsPage implements OnInit {
   currentBannerSponsor: any;
   hasLeadRetrieval: boolean = false;
   hasDoorCheck: boolean = false;
+  loggedIn: boolean = false;
 
   constructor(
     private userData: UserData,
     private confData: ConferenceData,
+    private actionSheetCtrl: ActionSheetController,
+    private router: Router,
   ) {}
 
   async ngOnInit() {
     this.reloadSponsors();
     this.checkHasLeadRetrieval();
+    this.checkHasDoorCheck();
+    this.checkLoggedIn();
     this.listenForLoginEvents();
     setInterval(this.showSponsorBanner, 30000);
+  }
+
+  checkLoggedIn() {
+    this.userData.isLoggedIn().then(loggedIn => {
+      this.loggedIn = loggedIn;
+    });
+  }
+
+  async openStaffTools(event: Event) {
+    event.stopPropagation();
+    event.preventDefault();
+
+    const buttons = [];
+    if (this.hasDoorCheck) {
+      buttons.push({
+        text: 'Door Check',
+        icon: 'checkbox-outline',
+        handler: () => { this.router.navigateByUrl('/app/tabs/door-check'); }
+      });
+      buttons.push({
+        text: 'Swag Pickup',
+        icon: 'gift-outline',
+        handler: () => { this.router.navigateByUrl('/app/tabs/t-shirt-redemption'); }
+      });
+    }
+    if (this.hasLeadRetrieval) {
+      buttons.push({
+        text: 'Lead Retrieval',
+        icon: 'qr-code-outline',
+        handler: () => { this.router.navigateByUrl('/app/tabs/lead-retrieval'); }
+      });
+    }
+    buttons.push({ text: 'Cancel', role: 'cancel', icon: 'close' });
+
+    const actionSheet = await this.actionSheetCtrl.create({
+      header: 'Staff Tools',
+      buttons
+    });
+    await actionSheet.present();
   }
 
   showSponsorBanner() {
@@ -78,15 +124,21 @@ export class TabsPage implements OnInit {
     }, 200)
   }
 
+  goTo(path: string) {
+    this.router.navigateByUrl(path);
+  }
+
   listenForLoginEvents() {
     window.addEventListener('user:login', () => {
       this.checkHasLeadRetrieval();
       this.checkHasDoorCheck();
+      this.checkLoggedIn();
     });
 
     window.addEventListener('user:logout', () => {
       this.checkHasLeadRetrieval();
       this.checkHasDoorCheck();
+      this.checkLoggedIn();
     });
   }
 }


### PR DESCRIPTION
## Summary
- **Map tab**: Quick access to conference center map
- **Account/Login tab**: Shows Account when logged in, Login when logged out
- **Scanner tab**: Staff-only action sheet with Door Check, Swag Pickup, Lead Retrieval
- Account and Login added as tab child routes so tab bar stays visible
- Tab order: Speakers, Map, Schedule, Scanner (staff), Account/Login

Resolves: PYC-110, PYC-111, PYC-112

## Test plan
- [x] Logged out: see Login tab, tapping shows login page with tab bar
- [x] Logged in: see Account tab, tapping shows account page with tab bar
- [x] Staff user: Scanner tab opens action sheet with available tools
- [x] Map tab navigates to conference map
- [x] All tabs work on iOS and Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)