### PR TITLE
Add AI, Security, Keynotes, Lightning Talks to sidebar

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -24,10 +24,14 @@ export class AppComponent implements OnInit {
   ]
   presentationPages = [
     { title: 'Talks',     group: 'presentations', url: '/app/tabs/tracks/talks',     icon: 'mic-outline'},
-    { title: 'Charlas',   group: 'presentations', url: '/app/tabs/tracks/charlas',   icon: 'mic-outline'},
-    { title: 'Tutorials', group: 'presentations', url: '/app/tabs/tracks/tutorials', icon: 'laptop-outline'},
-    { title: 'Posters',   group: 'presentations', url: '/app/tabs/tracks/posters',   icon: 'reader-outline'},
-    { title: 'Sponsor Presentations', url: '/app/tabs/tracks/sponsor-presentations', icon: 'mic-outline'},
+    { title: 'Keynotes',  group: 'presentations', url: '/app/tabs/tracks/keynotes',  icon: 'star-outline'},
+    { title: 'AI',        group: 'presentations', url: '/app/tabs/tracks/ais',       icon: 'hardware-chip-outline'},
+    { title: 'Security',  group: 'presentations', url: '/app/tabs/tracks/securitys', icon: 'shield-checkmark-outline'},
+    { title: 'Charlas',   group: 'presentations', url: '/app/tabs/tracks/charlas',   icon: 'chatbubbles-outline'},
+    { title: 'Lightning Talks', group: 'presentations', url: '/app/tabs/tracks/lightning-talkss', icon: 'flash-outline'},
+    { title: 'Tutorials', group: 'presentations', url: '/app/tabs/tracks/tutorials', icon: 'book-outline'},
+    { title: 'Posters',   group: 'presentations', url: '/app/tabs/tracks/posters',   icon: 'easel-outline'},
+    { title: 'Sponsor Presentations', url: '/app/tabs/tracks/sponsor-presentations', icon: 'briefcase-outline'},
   ]
   appPages = [
     { title: 'About PyCon US', url: '/app/tabs/about-pycon', icon: 'information-circle-outline' },


### PR DESCRIPTION
## Summary
- Add missing tracks to the Presentations dropdown: AI, Security, Keynotes, Lightning Talks
- Update existing track icons to match per-track icons used in schedule (Charlas→chatbubbles, Tutorials→book, Posters→easel, Sponsor Presentations→briefcase)

Resolves: PYC-113

## Test plan
- [x] Sidebar Presentations dropdown shows all tracks
- [x] Each track navigates to the correct filtered schedule view
- [x] Icons match the track badge icons
<img width="252" height="424" alt="image" src="https://github.com/user-attachments/assets/d41a4019-dbd3-4aa4-aafb-82aed1357813" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)