### PR TITLE
Improve schedule item metadata layout

### DIFF
--- a/src/app/pages/schedule/schedule.html
+++ b/src/app/pages/schedule/schedule.html
@@ -98,8 +98,12 @@
             <span class="track-badge" [attr.data-track]="session.track | lowercase">{{session.track | trackName}}</span>
             <span *ngIf="session.isSpanish" class="track-badge spanish-badge">En Español</span>
             <span *ngIf="session.preRegistered" class="track-badge prereg-badge">Pre-registration required</span>
-            <p>
-              {{session.timeStart}}<span *ngIf="session.timeStart !== session.timeEnd"> &mdash; {{session.timeEnd}}</span>: {{session.location}}<span *ngIf="session?.speakerNames?.length"> &mdash; {{session.speakerNames.join(', ')}}</span>
+            <p class="session-meta">
+              <span class="meta-item"><ion-icon name="time-outline"></ion-icon> {{session.timeStart}}<span *ngIf="session.timeStart !== session.timeEnd"> – {{session.timeEnd}}</span></span>
+              <span *ngIf="session.location" class="meta-item"><ion-icon name="location-outline"></ion-icon> {{session.location}}</span>
+            </p>
+            <p *ngIf="session?.speakerNames?.length" class="session-speakers">
+              <ion-icon name="person-outline"></ion-icon> {{session.speakerNames.join(', ')}}
             </p>
           </ion-label>
         </ion-item>

--- a/src/app/pages/schedule/schedule.scss
+++ b/src/app/pages/schedule/schedule.scss
@@ -40,6 +40,38 @@ ion-segment-button {
   min-width: auto;
 }
 
+.session-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75em;
+  font-size: 0.85em;
+  color: var(--ion-text-color, #000000);
+  margin: 4px 0 2px;
+}
+
+.meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+
+  ion-icon {
+    font-size: 0.95em;
+  }
+}
+
+.session-speakers {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.8em;
+  color: var(--ion-text-color, #000000);
+  margin: 2px 0 0;
+
+  ion-icon {
+    font-size: 0.95em;
+  }
+}
+
 .search-all-btn {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Split time/room/speakers into distinct visual elements with icons
- Time (clock icon) and room (pin icon) on one flex row
- Speakers (person icon) on their own line
- Full black text (respects dark mode via --ion-text-color)

Resolves: PYC-107

## Test plan
- [x] Schedule items show time, room, speakers as separate elements
- [x] Icons render correctly
- [x] Dark mode text is white

🤖 Generated with [Claude Code](https://claude.com/claude-code)