### PR TITLE
Show Speaker Discord button on account page for speakers

### DIFF
--- a/src/app/pages/account/account.html
+++ b/src/app/pages/account/account.html
@@ -14,6 +14,13 @@
     <h2>Signed in as {{nickname}}</h2>
     <p><code>{{email}}</code></p>
 
+    <ion-button *ngIf="isSpeaker" color="tertiary" (click)="openDiscord()">
+      <ion-icon slot="start" name="logo-discord"></ion-icon>
+      Speaker Discord
+    </ion-button>
+
+    <br *ngIf="isSpeaker">
+
     <ion-button (click)="logout()">Logout</ion-button>
 
   </div>

--- a/src/app/pages/account/account.ts
+++ b/src/app/pages/account/account.ts
@@ -5,6 +5,7 @@ import { NavController, AlertController } from '@ionic/angular';
 
 import { AppComponent } from '../../app.component';
 import { UserData } from '../../providers/user-data';
+import { ConferenceData } from '../../providers/conference-data';
 import { LiveUpdateService } from '../../providers/live-update.service';
 
 
@@ -16,6 +17,8 @@ import { LiveUpdateService } from '../../providers/live-update.service';
 export class AccountPage implements OnInit, AfterViewInit {
   email: string;
   nickname: string;
+  isSpeaker: boolean = false;
+  speakerDiscordUrl: string = 'https://us.pycon.org/2026/speaker/join_discord/';
 
   constructor(
     public app: AppComponent,
@@ -23,6 +26,7 @@ export class AccountPage implements OnInit, AfterViewInit {
     public nav: NavController,
     public router: Router,
     public userData: UserData,
+    public confData: ConferenceData,
     public liveUpdateService: LiveUpdateService,
   ) { }
 
@@ -33,6 +37,29 @@ export class AccountPage implements OnInit, AfterViewInit {
   ngAfterViewInit() {
     this.getEmail();
     this.getNickname();
+    this.checkIsSpeaker();
+  }
+
+  checkIsSpeaker() {
+    Promise.all([
+      this.userData.getNickname(),
+      this.userData.getEmail(),
+    ]).then(([nickname, email]) => {
+      if (!nickname && !email) return;
+      this.confData.load().subscribe((data: any) => {
+        if (data.speakers) {
+          const nick = (nickname || '').toLowerCase();
+          const em = (email || '').toLowerCase();
+          this.isSpeaker = data.speakers.some((s: any) => {
+            const name = (s.name || '').toLowerCase();
+            // Match: full name equals nickname, nickname is part of name, or bio contains email
+            return name === nick
+              || (nick.length > 2 && name.includes(nick))
+              || (em && s.about?.toLowerCase().includes(em));
+          });
+        }
+      });
+    });
   }
 
   getEmail() {
@@ -48,6 +75,10 @@ export class AccountPage implements OnInit, AfterViewInit {
       }
       this.nickname = nickname;
     });
+  }
+
+  openDiscord() {
+    window.open(this.speakerDiscordUrl, '_blank');
   }
 
   logout() {


### PR DESCRIPTION
## Summary
- Match logged-in user nickname against conference speaker names
- Show "Speaker Discord" button with Discord icon when user is a speaker
- Opens `us.pycon.org/2026/speaker/join_discord/` OAuth flow
- Non-speakers don't see the button

Resolves: PYC-100

## Test plan
- [ ] Log in as a speaker — Discord button appears
- [ ] Log in as non-speaker — no Discord button
- [ ] Tapping button opens the Discord join page

🤖 Generated with [Claude Code](https://claude.com/claude-code)