### PR TITLE
Hide Account tab when logged in

### DIFF
--- a/src/app/pages/tabs-page/tabs-page.html
+++ b/src/app/pages/tabs-page/tabs-page.html
@@ -30,11 +30,6 @@
       <ion-label>Scanner</ion-label>
     </ion-tab-button>
 
-    <ion-tab-button *ngIf="loggedIn" tab="account">
-      <ion-icon name="person-circle"></ion-icon>
-      <ion-label>Account</ion-label>
-    </ion-tab-button>
-
     <ion-tab-button *ngIf="!loggedIn" tab="login">
       <ion-icon name="log-in"></ion-icon>
       <ion-label>Login</ion-label>


### PR DESCRIPTION
## Summary
- Remove Account tab from bottom bar for logged-in users
- Login tab still shows when logged out
- Account page still accessible via side menu

Resolves: PYC-116

## Test plan
- [x] Logged out: Login tab visible
- [x] Logged in: no Account tab, account accessible via side menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)