### PR TITLE
Show Speaker Discord button for speakers on account page

### DIFF
--- a/src/app/pages/account/account.html
+++ b/src/app/pages/account/account.html
@@ -14,6 +14,13 @@
     <h2>Signed in as {{nickname}}</h2>
     <p><code>{{email}}</code></p>
 
+    <ion-button *ngIf="isSpeaker" color="tertiary" (click)="openSpeakerDiscord()">
+      <ion-icon slot="start" name="logo-discord"></ion-icon>
+      Speaker Discord
+    </ion-button>
+
+    <br>
+
     <ion-button (click)="logout()">Logout</ion-button>
 
   </div>

--- a/src/app/pages/account/account.ts
+++ b/src/app/pages/account/account.ts
@@ -2,10 +2,12 @@ import { AfterViewInit, Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { NavController, AlertController } from '@ionic/angular';
+import { InAppBrowser, DefaultWebViewOptions } from '@capacitor/inappbrowser';
 
 import { AppComponent } from '../../app.component';
 import { UserData } from '../../providers/user-data';
 import { LiveUpdateService } from '../../providers/live-update.service';
+import { environment } from '../../../environments/environment';
 
 
 @Component({
@@ -16,6 +18,7 @@ import { LiveUpdateService } from '../../providers/live-update.service';
 export class AccountPage implements OnInit, AfterViewInit {
   email: string;
   nickname: string;
+  isSpeaker: boolean = false;
 
   constructor(
     public app: AppComponent,
@@ -33,6 +36,7 @@ export class AccountPage implements OnInit, AfterViewInit {
   ngAfterViewInit() {
     this.getEmail();
     this.getNickname();
+    this.checkIsSpeaker();
   }
 
   getEmail() {
@@ -47,6 +51,19 @@ export class AccountPage implements OnInit, AfterViewInit {
         this.router.navigate(['/login'], { replaceUrl: true });
       }
       this.nickname = nickname;
+    });
+  }
+
+  checkIsSpeaker() {
+    this.userData.checkIsSpeaker().then((isSpeaker) => {
+      this.isSpeaker = !!isSpeaker;
+    });
+  }
+
+  openSpeakerDiscord() {
+    InAppBrowser.openInWebView({
+      url: environment.baseUrl + '/2026/speaker/join_discord/',
+      options: DefaultWebViewOptions,
     });
   }
 

--- a/src/app/providers/user-data.ts
+++ b/src/app/providers/user-data.ts
@@ -19,6 +19,7 @@ export class UserData {
   HAS_LEAD_RETRIEVAL = 'hasLeadRetrieval';
   HAS_DOOR_CHECK = 'hasDoorCheck';
   HAS_MASK_VIOLATION = 'hasMaskViolation';
+  IS_SPEAKER = 'isSpeaker';
 
   constructor(
     public storage: Storage,
@@ -132,6 +133,7 @@ export class UserData {
       this.setHasLeadRetrieval(data.features?.lead_retrieval);
       this.setHasDoorCheck(data.features?.door_check_in);
       this.setHasMaskViolation(data.features?.mask_violation);
+      this.setIsSpeaker(data.features?.is_speaker);
     }).then(() => {
       return window.dispatchEvent(new CustomEvent('user:login'));
     });
@@ -147,6 +149,7 @@ export class UserData {
       this.storage.remove(this.HAS_LEAD_RETRIEVAL);
       this.storage.remove(this.HAS_DOOR_CHECK);
       this.storage.remove(this.HAS_MASK_VIOLATION);
+      this.storage.remove(this.IS_SPEAKER);
     }).then(() => {
       window.dispatchEvent(new CustomEvent('user:logout'));
     });
@@ -230,6 +233,16 @@ export class UserData {
 
   checkHasMaskViolation(): Promise<boolean> {
     return this.storage.get(this.HAS_MASK_VIOLATION).then((value) => {
+      return value;
+    });
+  }
+
+  setIsSpeaker(value: boolean): Promise<any> {
+    return this.storage.set(this.IS_SPEAKER, value);
+  }
+
+  checkIsSpeaker(): Promise<boolean> {
+    return this.storage.get(this.IS_SPEAKER).then((value) => {
       return value;
     });
   }


### PR DESCRIPTION
## Summary
- Store `is_speaker` flag from API `features` response on login
- Show "Speaker Discord" button on account page when flag is true
- Opens `us.pycon.org/2026/speaker/join_discord/` in InAppBrowser
- Flag is gated by Discord waffle switch on the backend (PYC-119, merged)

Resolves: PYC-100

## Test plan
- [x] Login as speaker (with Discord enabled) — Discord button appears
- [x] Login as non-speaker — no Discord button
- [x] Tapping button opens Discord join flow
- [x] Logout clears the flag
<img width="275" height="301" alt="image" src="https://github.com/user-attachments/assets/b54ee77e-dae2-476c-aee2-c4c14c865c09" />
<img width="275" height="452" alt="image" src="https://github.com/user-attachments/assets/7cb3afb0-a9f2-43b6-8215-856d4787e590" />
<img width="265" height="215" alt="image" src="https://github.com/user-attachments/assets/7d31259c-75e7-44f6-86be-f4c1ceafd948" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)