### PR TITLE
Consolidate schedule header — single row with day tabs

### DIFF
--- a/src/app/pages/schedule/schedule.html
+++ b/src/app/pages/schedule/schedule.html
@@ -1,54 +1,22 @@
 <ion-header translucent="true">
-  <ion-toolbar>
-    <ion-buttons *ngIf="!showSearchbar" slot="start">
+  <ion-toolbar class="schedule-toolbar">
+    <ion-buttons slot="start">
       <ion-menu-button [color]="liveUpdateService.needsUpdate ? 'primary' : 'medium'"></ion-menu-button>
       <ion-badge *ngIf="liveUpdateService.needsUpdate" size=sm>1</ion-badge>
     </ion-buttons>
-    <ion-segment *ngIf="ios" [(ngModel)]="segment" (ionChange)="updateSchedule()">
-      <ion-segment-button value="all">
-        All
-      </ion-segment-button>
-      <ion-segment-button value="favorites">
-        Favorites
+    <ion-segment [(ngModel)]="dayIndex" (ionChange)="updateSchedule()" class="day-segment">
+      <ion-segment-button *ngFor="let day of days" value="{{day.index}}" [class.today-tab]="day.index === todayIndex">
+        {{day.day}}
       </ion-segment-button>
     </ion-segment>
-    <ion-title *ngIf="!ios && !showSearchbar">Schedule</ion-title>
-    <ion-searchbar #search *ngIf="showSearchbar" showCancelButton="always" [(ngModel)]="queryText" (ionChange)="updateSchedule()" (ionCancel)="showSearchbar = false" placeholder="Search"></ion-searchbar>
     <ion-buttons slot="end">
-      <ion-button *ngIf="!ios && !showSearchbar" (click)="showSearchbar = true && focusButton()">
-        <ion-icon slot="icon-only" name="search"></ion-icon>
+      <ion-button (click)="toggleFavorites()" class="header-action">
+        <ion-icon slot="icon-only" [name]="segment === 'favorites' ? 'star' : 'star-outline'"></ion-icon>
       </ion-button>
-      <ion-button *ngIf="!showSearchbar" (click)="presentFilter()">
-        <span *ngIf="ios">Filter</span>
-        <span *ngIf="!ios">
-          <ion-icon slot="icon-only" name="options"></ion-icon>
-        </span>
+      <ion-button (click)="presentFilter()" class="header-action">
+        <ion-icon slot="icon-only" name="funnel-outline"></ion-icon>
       </ion-button>
     </ion-buttons>
-  </ion-toolbar>
-  <ion-toolbar *ngIf="ios">
-    <ion-segment [(ngModel)]="dayIndex" (ionChange)="updateSchedule()">
-      <ion-segment-button *ngFor="let day of days" value="{{day.index}}" [class.today-tab]="day.index === todayIndex">
-        {{day.day}}
-      </ion-segment-button>
-    </ion-segment>
-  </ion-toolbar>
-  <ion-toolbar *ngIf="!ios">
-    <ion-segment [(ngModel)]="segment" (ionChange)="updateSchedule()">
-      <ion-segment-button value="all">
-        All
-      </ion-segment-button>
-      <ion-segment-button value="favorites">
-        Favorites
-      </ion-segment-button>
-    </ion-segment>
-  </ion-toolbar>
-  <ion-toolbar *ngIf="!ios">
-    <ion-segment [(ngModel)]="dayIndex" (ionChange)="updateSchedule()">
-      <ion-segment-button *ngFor="let day of days" value="{{day.index}}" [class.today-tab]="day.index === todayIndex">
-        {{day.day}}
-      </ion-segment-button>
-    </ion-segment>
   </ion-toolbar>
 </ion-header>
 
@@ -57,14 +25,10 @@
     <ion-refresher-content></ion-refresher-content>
   </ion-refresher>
 
-  <ion-header collapse="condense">
-    <ion-toolbar>
-      <ion-title size="large">Schedule</ion-title>
-    </ion-toolbar>
-    <ion-toolbar>
-      <ion-searchbar [(ngModel)]="queryText" (ionChange)="updateSchedule()" placeholder="Search"></ion-searchbar>
-    </ion-toolbar>
-  </ion-header>
+  <ion-toolbar class="search-toolbar">
+    <ion-searchbar [(ngModel)]="queryText" (ionChange)="updateSchedule()" placeholder="Search sessions"></ion-searchbar>
+  </ion-toolbar>
+
 
   <ion-list #scheduleList [hidden]="shownSessions !== 0">
     <ion-item>

--- a/src/app/pages/schedule/schedule.scss
+++ b/src/app/pages/schedule/schedule.scss
@@ -36,18 +36,62 @@ $tracks: (
   }
 }
 
-ion-segment-button {
-  min-width: auto;
+:host {
+  --pycon-accent: #680579;
 }
 
-ion-segment-button.today-tab {
-  --indicator-color: #680579;
-  --color: #680579;
-  --color-checked: #ffffff;
-  --background-checked: #680579;
+:host-context(.dark-theme) {
+  --pycon-accent: #DD04D2;
+}
+
+.schedule-toolbar {
+  --padding-start: 0;
+  --padding-end: 0;
+}
+
+.day-segment {
+  --background: transparent;
+}
+
+.day-segment ion-segment-button {
+  --indicator-height: 3px;
+  --indicator-color: var(--pycon-accent, #680579);
+  --color: var(--ion-color-step-500, #808080);
+  --color-checked: var(--pycon-accent, #680579);
+  min-width: auto;
+  font-size: 0.85rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: none;
+}
+
+.day-segment ion-segment-button.today-tab {
+  --color: var(--pycon-accent, #680579);
   font-weight: 700;
-  border-radius: 8px;
-  border-bottom: 3px solid #680579;
+}
+
+.header-action {
+  --color: var(--ion-color-step-500, #808080);
+  font-size: 1.1rem;
+
+  &:active {
+    --color: #680579;
+  }
+}
+
+.search-toolbar {
+  --background: transparent;
+  --border-width: 0;
+  padding: 0 8px 4px;
+}
+
+.search-toolbar ion-searchbar {
+  --border-radius: 10px;
+  --box-shadow: none;
+  --background: var(--ion-color-step-50, #f2f2f2);
+  font-size: 0.9rem;
+  padding: 0;
+  height: 36px;
 }
 
 .jump-now-wrapper {

--- a/src/app/pages/schedule/schedule.ts
+++ b/src/app/pages/schedule/schedule.ts
@@ -168,6 +168,11 @@ export class SchedulePage implements OnInit, OnDestroy {
     });
   }
 
+  toggleFavorites() {
+    this.segment = this.segment === 'favorites' ? 'all' : 'favorites';
+    this.updateSchedule();
+  }
+
   searchAllDays() {
     let found = false;
     let checked = 0;


### PR DESCRIPTION
## Summary
- Remove All/Favorites segment — replaced with star toggle icon in header
- Day selector moved up to main toolbar (single row: menu | days | star | filter)
- Filter changed from text to funnel icon
- Search bar in content area, compact rounded style
- Today's tab highlighted purple
- Clean, minimal header maximizes content space

Resolves: PYMOBIL-67

## Test plan
- [x] Day tabs work, today highlighted
- [x] Star toggles favorites on/off
- [x] Filter opens filter modal
- [x] Search bar filters sessions
- [x] Single toolbar row on all devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)