### PR TITLE
Fix schedule showing only headers when navigating back

### DIFF
--- a/src/app/pages/schedule/schedule.ts
+++ b/src/app/pages/schedule/schedule.ts
@@ -86,7 +86,12 @@ export class SchedulePage implements OnInit, OnDestroy {
     }
   }
 
+  ionViewWillEnter() {
+    this.updateSchedule();
+  }
+
   ionViewDidEnter() {
+    this.changeDetectorRef.detectChanges();
     this.jumpBtnCollapsed = false;
     setTimeout(() => { this.jumpBtnCollapsed = true; }, 3000);
     if (this.dayIndex === this.todayIndex) {


### PR DESCRIPTION
## Summary
- Add `ionViewWillEnter` to re-fetch schedule data on tab re-entry
- Add `changeDetectorRef.detectChanges()` in `ionViewDidEnter` to force re-render
- Fixes blank schedule (only time headers visible) after navigating back from session/speaker detail

Resolves: PYMOBIL-72

## Test plan
- [x] Open a session detail → navigate back → schedule shows sessions
- [x] Open speaker detail → navigate back → schedule shows sessions
- [x] Switch tabs → return to schedule → sessions visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)