### PR TITLE
Add helpful empty state for favorites

### DIFF
--- a/src/app/pages/schedule/schedule.html
+++ b/src/app/pages/schedule/schedule.html
@@ -31,17 +31,25 @@
 
 
   <ion-list #scheduleList [hidden]="shownSessions !== 0">
-    <ion-item>
-      <ion-text color="medium">No sessions found that match your current filters</ion-text>
-    </ion-item>
-    <ion-item *ngIf="queryText" lines="none" class="ion-text-center">
-      <ion-label>
-        <button class="search-all-btn" [class.exhausted]="searchedAllDays" [disabled]="searchedAllDays" (click)="searchAllDays()">
-          {{ searchedAllDays ? 'No results on any day' : 'Search all days' }}
-          <ion-icon [name]="searchedAllDays ? 'close-circle-outline' : 'calendar-outline'"></ion-icon>
-        </button>
-      </ion-label>
-    </ion-item>
+    <div *ngIf="segment === 'favorites'" class="ion-padding ion-text-center empty-favorites">
+      <ion-icon name="star-outline" class="empty-icon"></ion-icon>
+      <h2>No favorites yet</h2>
+      <p>Browse the schedule and tap the <ion-icon name="star-outline" style="font-size: 1em; vertical-align: middle;"></ion-icon> on sessions you're interested in to build your personal schedule.</p>
+      <ion-button fill="clear" size="small" (click)="toggleFavorites()">Show all sessions</ion-button>
+    </div>
+    <div *ngIf="segment !== 'favorites'">
+      <ion-item>
+        <ion-text color="medium">No sessions found that match your current filters</ion-text>
+      </ion-item>
+      <ion-item *ngIf="queryText" lines="none" class="ion-text-center">
+        <ion-label>
+          <button class="search-all-btn" [class.exhausted]="searchedAllDays" [disabled]="searchedAllDays" (click)="searchAllDays()">
+            {{ searchedAllDays ? 'No results on any day' : 'Search all days' }}
+            <ion-icon [name]="searchedAllDays ? 'close-circle-outline' : 'calendar-outline'"></ion-icon>
+          </button>
+        </ion-label>
+      </ion-item>
+    </div>
   </ion-list>
 
   <ion-list #scheduleList [hidden]="shownSessions === 0">

--- a/src/app/pages/schedule/schedule.scss
+++ b/src/app/pages/schedule/schedule.scss
@@ -94,6 +94,29 @@ $tracks: (
   height: 36px;
 }
 
+.empty-favorites {
+  padding-top: 60px;
+
+  .empty-icon {
+    font-size: 48px;
+    color: var(--ion-color-step-300, #b0b0b0);
+  }
+
+  h2 {
+    font-size: 1.2rem;
+    font-weight: 600;
+    margin: 12px 0 8px;
+  }
+
+  p {
+    font-size: 0.9rem;
+    color: var(--ion-color-step-500, #808080);
+    line-height: 1.5;
+    max-width: 280px;
+    margin: 0 auto 16px;
+  }
+}
+
 .jump-now-wrapper {
   position: absolute;
   bottom: 16px;


### PR DESCRIPTION
## Summary
- Show contextual empty state when favorites filter is active with no favorites
- Star icon + helpful text explaining how to favorite sessions
- "Show all sessions" button to toggle back to all
- Generic filter message preserved for non-favorites empty states

Resolves: PYMOBIL-69

## Test plan
- [x] Toggle favorites with no favorites → shows helpful message
- [x] "Show all sessions" button switches back to all
- [x] Search with no results still shows generic message + search all days
<img width="402" height="368" alt="image" src="https://github.com/user-attachments/assets/d0bb0818-98d1-4f1b-838d-5da87dee5b3c" />
<img width="368" height="224" alt="image" src="https://github.com/user-attachments/assets/1535e80f-8e7c-4296-85bf-c2bf4eee5ba6" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)