### PR TITLE
Fix account and login pages missing tab bar

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -107,7 +107,7 @@
           </ion-list-header>
 
           <ion-menu-toggle autoHide="false">
-            <ion-item routerLink="/account" routerLinkActive="active" routerDirection="root" detail="false">
+            <ion-item routerLink="/app/tabs/account" routerLinkActive="active" routerDirection="root" detail="false">
               <ion-icon slot="start" name="person"></ion-icon>
               <ion-label>
                 Account
@@ -123,7 +123,7 @@
           </ion-list-header>
 
           <ion-menu-toggle autoHide="false">
-            <ion-item routerLink="/login" routerLinkActive="active" routerDirection="root" detail="false">
+            <ion-item routerLink="/app/tabs/login" routerLinkActive="active" routerDirection="root" detail="false">
               <ion-icon slot="start" name="log-in"></ion-icon>
               <ion-label>
                 Login

--- a/src/app/pages/account/account.ts
+++ b/src/app/pages/account/account.ts
@@ -48,7 +48,7 @@ export class AccountPage implements OnInit, AfterViewInit {
   getNickname() {
     this.userData.getNickname().then((nickname) => {
       if (nickname === null) {
-        this.router.navigate(['/login'], { replaceUrl: true });
+        this.router.navigate(['/app/tabs/login'], { replaceUrl: true });
       }
       this.nickname = nickname;
     });


### PR DESCRIPTION
## Summary
- Change side menu links from `/account` → `/app/tabs/account` and `/login` → `/app/tabs/login`
- Fix account page redirect to use tab-scoped login route
- Tab bar now visible on account and login pages when accessed from side menu

Resolves: PYMOBIL-47

## Test plan
- [x] Side menu → Account → tab bar visible
- [x] Side menu → Login → tab bar visible
- [x] Account page (not logged in) redirects to login with tab bar
<img width="352" height="662" alt="image" src="https://github.com/user-attachments/assets/d4996282-5542-4ac5-9ccd-a9f5fb572eb5" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)