### PR TITLE
Add cancel button to dismiss keyboard on search fields

### DIFF
--- a/src/app/pages/schedule-list/schedule-list.page.html
+++ b/src/app/pages/schedule-list/schedule-list.page.html
@@ -15,7 +15,7 @@
 
 <ion-content fullscreen="true">
   <ion-toolbar class="search-toolbar">
-    <ion-searchbar [(ngModel)]="sessionQueryText" [debounce]="250" (ionClear)="resetSessions()" (ionCancel)="resetSessions()" (ionChange)="searchSessions()" placeholder="Search"></ion-searchbar>
+    <ion-searchbar [(ngModel)]="sessionQueryText" [debounce]="250" showCancelButton="focus" inputmode="search" (ionClear)="resetSessions()" (ionCancel)="resetSessions()" (ionChange)="searchSessions()" placeholder="Search"></ion-searchbar>
   </ion-toolbar>
 
   <!-- Regular sessions display -->

--- a/src/app/pages/schedule/schedule.html
+++ b/src/app/pages/schedule/schedule.html
@@ -26,7 +26,7 @@
   </ion-refresher>
 
   <ion-toolbar class="search-toolbar">
-    <ion-searchbar [(ngModel)]="queryText" (ionChange)="updateSchedule()" placeholder="Search sessions"></ion-searchbar>
+    <ion-searchbar [(ngModel)]="queryText" (ionChange)="updateSchedule()" showCancelButton="focus" inputmode="search" placeholder="Search sessions"></ion-searchbar>
   </ion-toolbar>
 
 


### PR DESCRIPTION
## Summary
- Add `showCancelButton="focus"` to schedule and schedule-list search bars
- Add `inputmode="search"` so iOS shows "Search" key with dismiss action
- Cancel button appears when search is focused, dismisses keyboard on tap

Resolves: PYMOBIL-73

## Test plan
- [ ] Tap search on schedule → Cancel button appears → tapping dismisses keyboard
- [ ] Tap search on track view → same behavior
- [ ] iOS keyboard shows "Search" key
<img width="396" height="94" alt="image" src="https://github.com/user-attachments/assets/5a4426b1-fad2-4c72-8c06-92d3d1eb9e2a" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)