### PR TITLE
Redesign session detail page

### DIFF
--- a/src/app/pages/schedule-list/schedule-list.page.html
+++ b/src/app/pages/schedule-list/schedule-list.page.html
@@ -19,34 +19,31 @@
   </ion-toolbar>
 
   <!-- Regular sessions display -->
-  <ion-grid *ngIf="!isOpenSpaceView">
-    <ion-row>
-      <ion-col size-xl="6" size-md="6" size-sm="6" size-xs="12" *ngFor="let session of displaySessions" [hidden]="session.hide">
-        <ion-item class="ion-no-padding" lines="none" detail="false" routerLink="/app/tabs/schedule/session/{{session.id}}">
-          <ion-card class="ion-no-padding ion-no-border ion-margin-bottom session-card">
-            <ion-card-header>
-              <ion-card-title class="session-card-title">
-                  <ion-icon *ngIf="session.favorite" slot="icon-only" name="star"></ion-icon>
-                  {{session.name}}
-              </ion-card-title>
-              <ion-card-subtitle>
-                  <span class="track-badge" [attr.data-track]="session.track | lowercase">{{session.track | trackName}}</span>
-                  {{session.day}} {{session.timeStart}} &mdash; {{session.timeEnd}}: {{session.location}}
-              </ion-card-subtitle>
-            </ion-card-header>
-            <ion-card-content>
-              <ion-chip *ngFor="let speaker of session.speakers">
-              <ion-avatar>
-                <img [src]="speaker.profilePic" [alt]="speaker.name + ' profile picture'">
-              </ion-avatar>
-              <ion-label>{{ speaker.name }}</ion-label>
-              </ion-chip>
-            </ion-card-content>
-          </ion-card>
-        </ion-item>
-      </ion-col>
-    </ion-row>
-  </ion-grid>
+  <ion-list *ngIf="!isOpenSpaceView">
+    <ion-item *ngFor="let session of displaySessions" [hidden]="session.hide" detail="true" routerLink="/app/tabs/schedule/session/{{session.id}}" [attr.track]="session.track | lowercase" class="session-list-item">
+      <ion-label>
+        <h2 class="session-name">
+          <ion-icon *ngIf="session.favorite" name="star" color="warning" style="font-size: 0.85em; margin-right: 4px;"></ion-icon>
+          {{session.name}}
+        </h2>
+        <div class="session-badges">
+          <span class="track-badge" [attr.data-track]="session.track | lowercase">{{session.track | trackName}}</span>
+          <span *ngIf="session?.isSpanish" class="track-badge spanish-badge">En Español</span>
+          <span *ngIf="session?.preRegistered" class="track-badge prereg-badge">Pre-registration required</span>
+        </div>
+        <p class="session-meta">
+          <span class="meta-item"><ion-icon name="time-outline"></ion-icon> {{session.day}} {{session.timeStart}} – {{session.timeEnd}}</span>
+          <span *ngIf="session.location" class="meta-item"><ion-icon name="location-outline"></ion-icon> {{session.location}}</span>
+        </p>
+        <div *ngIf="session.speakers?.length" class="speaker-avatars">
+          <ion-avatar *ngFor="let speaker of session.speakers" class="speaker-avatar-small">
+            <img [src]="speaker.profilePic" [alt]="speaker.name">
+          </ion-avatar>
+          <span class="speaker-names">{{session.speakerNames.join(', ')}}</span>
+        </div>
+      </ion-label>
+    </ion-item>
+  </ion-list>
 
   <!-- Open sapces display with day headers -->
   <div *ngIf="isOpenSpaceView">

--- a/src/app/pages/schedule-list/schedule-list.page.scss
+++ b/src/app/pages/schedule-list/schedule-list.page.scss
@@ -34,14 +34,82 @@
   margin-right: 12px;
 }
 
-.session-card {
-  width: 100%;
-  box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1);
-  border-radius: 8px;
+$tracks: (
+  talk: #5833E9,
+  tutorial: #DD04D2,
+  keynote: #680579,
+  plenary: #630675,
+  break: #3A3A3A,
+  lightning-talks: #C05CA0,
+  security: #F19C0B,
+  ai: #10B57F,
+  charla: #527CB2,
+  poster: #D47454,
+  sponsor\ presentation: #FFD779,
+  open\ space: #6FCF97,
+);
+
+@each $track, $color in $tracks {
+  ion-item[track='#{$track}'] ion-label {
+    border-left: 3px solid $color;
+    padding-left: 10px;
+  }
 }
 
-.session-card-title {
-  font-size: 1.1em;
+.session-list-item {
+  --padding-top: 10px;
+  --padding-bottom: 10px;
+}
+
+.session-name {
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.3;
+  margin-bottom: 4px;
+}
+
+.session-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+
+.session-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75em;
+  font-size: 0.85em;
+  color: var(--ion-text-color);
+  margin: 4px 0 2px;
+}
+
+.meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+
+  ion-icon {
+    font-size: 0.95em;
+  }
+}
+
+.speaker-avatars {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.speaker-avatar-small {
+  width: 28px;
+  height: 28px;
+  min-width: 28px;
+}
+
+.speaker-names {
+  font-size: 0.8rem;
+  color: var(--ion-color-step-500, #808080);
 }
 
 .day-header {

--- a/src/app/pages/session-detail/session-detail.html
+++ b/src/app/pages/session-detail/session-detail.html
@@ -6,55 +6,55 @@
     <ion-buttons slot="end">
       <ion-button (click)="toggleFavorite()">
         <ion-icon *ngIf="!isFavorite" slot="icon-only" name="star-outline"></ion-icon>
-        <ion-icon *ngIf="isFavorite" slot="icon-only" name="star"></ion-icon>
+        <ion-icon *ngIf="isFavorite" slot="icon-only" name="star" color="warning"></ion-icon>
       </ion-button>
     </ion-buttons>
   </ion-toolbar>
 </ion-header>
 
 <ion-content>
-  <div *ngIf="session" class="ion-padding">
-    <h1>{{session.name}}</h1>
-    <span *ngFor="let track of session?.tracks" class="track-badge" [attr.data-track]="track | lowercase">{{track | trackName : 'long'}}</span>
-    <span *ngFor="let track of session?.tracks">
-      <span *ngIf="(track | lowercase) === 'ai' || (track | lowercase) === 'security'" class="track-badge new-badge">New track!</span>
-    </span>
-    <span *ngIf="session?.isSpanish" class="track-badge spanish-badge">En Español</span>
-    <span *ngIf="session?.preRegistered" class="track-badge prereg-badge">Pre-registration required</span>
-    <div [innerHtml]="session?.description" (click)="onDescriptionClick($event)">
+  <div *ngIf="session" class="session-detail-content">
+    <h1 class="session-title">{{session.name}}</h1>
+
+    <div class="session-badges">
+      <span *ngFor="let track of session?.tracks" class="track-badge" [attr.data-track]="track | lowercase">{{track | trackName : 'long'}}</span>
+      <span *ngFor="let track of session?.tracks">
+        <span *ngIf="(track | lowercase) === 'ai' || (track | lowercase) === 'security'" class="track-badge new-badge">New track!</span>
+      </span>
+      <span *ngIf="session?.isSpanish" class="track-badge spanish-badge">En Español</span>
+      <span *ngIf="session?.preRegistered" class="track-badge prereg-badge">Pre-registration required</span>
     </div>
-    <ion-text color="medium">
-      {{session.day}} {{session.date}} - {{session.timeStart}} &ndash; {{session.timeEnd}}
-      <br /> {{session.location}}
-      <p *ngIf="session.preRegistered">Pre-registration required to attend this event.</p>
-    </ion-text>
+
+    <div class="session-meta-card">
+      <div class="meta-row">
+        <ion-icon name="time-outline"></ion-icon>
+        <span>{{session.day}} {{session.timeStart}}<span *ngIf="session.timeStart !== session.timeEnd"> – {{session.timeEnd}}</span></span>
+      </div>
+      <div *ngIf="session.location" class="meta-row">
+        <ion-icon name="location-outline"></ion-icon>
+        <span>{{session.location}}</span>
+      </div>
+    </div>
+
+    <div *ngIf="session.speakers?.length > 0" class="session-speakers-section">
+      <ion-item *ngFor="let speaker of session.speakers" lines="none" detail="true" class="speaker-item"
+        [routerLink]="['/app/tabs/speakers/speaker-details', speaker.id]"
+        [queryParams]="{ prevUrl: location.path() }">
+        <ion-avatar slot="start">
+          <img [src]="speaker.profilePic" [alt]="speaker.name">
+        </ion-avatar>
+        <ion-label>
+          <h2>{{speaker.name}}</h2>
+          <p>Speaker</p>
+        </ion-label>
+      </ion-item>
+    </div>
 
     <div *ngIf="session.imageUrl" class="session-image-container">
       <img [src]="session.imageUrl" class="session-image">
     </div>
 
-    <div *ngIf="session.speakers.length > 0">
-      <h3>Presented by</h3>
-      <ion-grid fixed>
-        <ion-row>
-          <ion-col size="12" size-md="6" *ngFor="let speaker of session.speakers">
-            <ion-card class="speaker-card">
-              <ion-card-header>
-                <ion-item detail="false" lines="none" class="speaker-item" [routerLink]="['/app/tabs/speakers/speaker-details', speaker.id]"
-                [queryParams]="{ prevUrl: location.path() }">
-                  <ion-avatar slot="start">
-                    <img [src]="speaker.profilePic" [alt]="speaker.name + ' profile picture'">
-                  </ion-avatar>
-                  <ion-label>
-                    <h2>{{speaker.name}}</h2>
-
-                  </ion-label>
-                </ion-item>
-              </ion-card-header>
-            </ion-card>
-          </ion-col>
-        </ion-row>
-      </ion-grid>
+    <div class="session-description" [innerHtml]="session?.description" (click)="onDescriptionClick($event)">
     </div>
   </div>
 </ion-content>

--- a/src/app/pages/session-detail/session-detail.scss
+++ b/src/app/pages/session-detail/session-detail.scss
@@ -1,88 +1,72 @@
-.session-track-ionic {
-  color: var(--ion-color-primary);
+.session-detail-content {
+  padding: 20px 16px;
 }
 
-.session-track-angular {
-  color: var(--ion-color-angular);
+.session-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.25;
+  margin: 0 0 12px;
 }
 
-.session-track-communication {
-  color: var(--ion-color-communication);
+.session-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 16px;
 }
 
-.session-track-tooling {
-  color: var(--ion-color-tooling);
+.session-meta-card {
+  background: var(--ion-color-step-50, #f5f5f5);
+  border-radius: 12px;
+  padding: 14px 16px;
+  margin-bottom: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
-.session-track-services {
-  color: var(--ion-color-services);
+:host-context(.dark-theme) .session-meta-card {
+  background: var(--ion-color-step-100, #1a1a1a);
 }
 
-.session-track-design {
-  color: var(--ion-color-design);
+.meta-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.95rem;
+
+  ion-icon {
+    font-size: 1.2em;
+    color: var(--ion-color-step-500, #808080);
+    flex-shrink: 0;
+  }
 }
 
-.session-track-workshop {
-  color: var(--ion-color-workshop);
-}
+.session-speakers-section {
+  margin-bottom: 20px;
 
-.session-track-food {
-  color: var(--ion-color-food);
-}
+  .speaker-item {
+    --padding-start: 0;
+    --inner-padding-end: 0;
+    --background: transparent;
 
-.session-track-documentation {
-  color: var(--ion-color-documentation);
-}
+    ion-avatar {
+      width: 44px;
+      height: 44px;
+      margin-right: 12px;
+    }
 
-.session-track-navigation {
-  color: var(--ion-color-navigation);
-}
+    h2 {
+      font-weight: 600;
+      font-size: 1rem;
+    }
 
-/* Favorite Icon
- * --------------------------------------------------------
- */
-
-.show-favorite {
-  position: relative;
-}
-
-.icon-heart-empty,
-.icon-heart {
-  --border-radius: 50%;
-  --padding-start: 0;
-  --padding-end: 0;
-
-  position: absolute;
-
-  top: 5px;
-  right: 5px;
-
-  width: 48px;
-  height: 48px;
-
-  font-size: 16px;
-
-  transition: transform 300ms ease;
-}
-
-.icon-heart-empty {
-  transform: scale(1);
-}
-
-.icon-heart {
-  transform: scale(0);
-}
-
-.show-favorite .icon-heart {
-  transform: scale(1);
-}
-
-.show-favorite .icon-heart-empty {
-  transform: scale(0);
-}
-
-h1 {
-  margin: 0;
+    p {
+      font-size: 0.8rem;
+      color: var(--ion-color-step-500, #808080);
+    }
+  }
 }
 
 .session-image-container {
@@ -93,6 +77,21 @@ h1 {
 .session-image {
   max-width: 100%;
   max-height: 300px;
-  border-radius: 8px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.session-description {
+  font-size: 0.95rem;
+  line-height: 1.65;
+  color: var(--ion-text-color);
+
+  p {
+    margin: 0 0 12px;
+  }
+
+  a {
+    color: var(--ion-color-primary);
+    text-decoration: none;
+  }
 }


### PR DESCRIPTION
## Summary
- Restructured layout: title → badges → meta card → speakers → description
- Time and location in a clean rounded card with icons
- Speaker items with avatars and navigation
- Description moved below speakers for better flow
- Dark mode support for meta card
- Removed old unused track color classes

Resolves: PYMOBIL-75

## Test plan
- [ ] Session detail shows clean layout with meta card
- [ ] Speaker avatars link to speaker detail
- [ ] Description links open in InAppBrowser
- [ ] Dark mode looks clean
<img width="395" height="716" alt="image" src="https://github.com/user-attachments/assets/a92c5480-d4b9-488b-94b5-3dbdb7a23fc6" />
<img width="381" height="330" alt="image" src="https://github.com/user-attachments/assets/6e8bc587-0292-4919-bdd4-d5fc15fa34b9" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)