### PR TITLE
Make content text selectable/copyable

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -34,6 +34,20 @@
 
 @import "./app/app.scss";
 
+/* Allow text selection for content text */
+ion-content p,
+ion-content h1,
+ion-content h2,
+ion-content h3,
+ion-content h4,
+ion-content h5,
+ion-content h6,
+ion-content ion-text,
+ion-content ion-label {
+  user-select: text;
+  -webkit-user-select: text;
+}
+
 /*
  * Track badges — shared across schedule, speaker, and session pages
  */


### PR DESCRIPTION
## Summary
- Adds `user-select: text` to content text elements (`p`, `h1`-`h6`, `ion-text`, `ion-label`) so users can copy speaker names, bios, session titles, and other readable text
- Scoped to `ion-content` only — does not affect navigation or interactive UI elements

Supersedes #112 — takes the text selection CSS from @deveshbervar's PR, applied against current main. The back button color change from that PR was excluded as it would break dark mode on the speaker page (toolbar is already styled white-on-purple).

## Test plan
- [ ] Verify text is selectable on speaker detail, session detail, and schedule pages
- [ ] Verify buttons, nav items, and interactive elements are not affected
- [ ] Check both iOS and Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)