### PR TITLE
Fix app version display and bump platform minimums

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "org.pycon.us"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 4000
-        versionName "4.0.0"
+        versionCode 260000
+        versionName "26.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -1,5 +1,5 @@
 ext {
-    minSdkVersion = 26
+    minSdkVersion = 34
     compileSdkVersion = 35
     targetSdkVersion = 35
     androidxActivityVersion = '1.9.2'

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -300,7 +300,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -355,7 +355,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -376,12 +376,12 @@
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "PyCon US";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.0.0;
+				MARKETING_VERSION = 26.0.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = org.pycon.us.2023.onsite;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -406,12 +406,12 @@
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "PyCon US";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.0.0;
+				MARKETING_VERSION = 26.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.pycon.us.2023.onsite;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ionic-conference-app",
-  "version": "0.0.0",
+  "version": "26.0.0",
   "description": "Ionic Conference App",
   "author": "Ionic Team <hi@ionicframework.com>",
   "license": "Apache-2.0",

--- a/src/app/pages/about-pycon/about-pycon.page.html
+++ b/src/app/pages/about-pycon/about-pycon.page.html
@@ -30,7 +30,7 @@
       <br>
       <br>
       <ion-col>
-        <ion-text>App Version: {{liveUpdateService.build}}</ion-text>
+        <ion-text>App Version: {{liveUpdateService.appVersion}} (build {{liveUpdateService.build}})</ion-text>
         <br>
         <ion-button *ngIf="loggedIn" (click)="shareDebug()">Share Debug Info with PyCon Staff</ion-button>
         <br>

--- a/src/app/providers/live-update.service.ts
+++ b/src/app/providers/live-update.service.ts
@@ -9,6 +9,7 @@ export class LiveUpdateService {
   updateAvailable: any = null;
   needsUpdate: boolean = false;
   build: string = "base";
+  appVersion: string = "";
 
   constructor() {
     App.addListener('appStateChange', ({ isActive }) => {
@@ -20,8 +21,8 @@ export class LiveUpdateService {
 
   async updateAppInfo() {
     const info = await App.getInfo();
-    this.build = info.name + " " + info.version + "-" + info.build
-    console.log(this.build);
+    this.appVersion = info.version;
+    this.build = info.build;
   }
 
   async reload() {


### PR DESCRIPTION
## Summary
- Fix About page showing Appflow live update build ID instead of real app version — now shows `App Version: 26.0.0 (build X)` with both values read dynamically from `App.getInfo()`
- Sync repo version numbers to 26.0.0 (package.json, build.gradle, Xcode project)
- Bump iOS deployment target: 16.0 → 18.0
- Bump Android minSdk: 26 (Android 8) → 34 (Android 14)

## Test plan
- [x] Verify About page shows correct version and build number
- [x] Verify iOS build with deployment target 18.0
- [x] Verify Android build with minSdk 34

🤖 Generated with [Claude Code](https://claude.com/claude-code)