### PR TITLE
Add session badge legend to About page

### DIFF
--- a/src/app/pages/about-pycon/about-pycon.page.html
+++ b/src/app/pages/about-pycon/about-pycon.page.html
@@ -25,6 +25,59 @@
     </ion-col>
     </ion-row>
     <ion-row>
+      <ion-col>
+        <h2 class="legend-heading">Session Types</h2>
+        <p class="legend-intro">Sessions in the schedule are color-coded by type:</p>
+        <div class="legend-list">
+          <div class="legend-item">
+            <span class="track-badge" data-track="talk">Talk</span>
+            <span class="legend-desc">Standard conference presentations (30 min)</span>
+          </div>
+          <div class="legend-item">
+            <span class="track-badge" data-track="tutorial">Tutorial</span>
+            <span class="legend-desc">In-depth hands-on sessions (3 hrs, separate registration)</span>
+          </div>
+          <div class="legend-item">
+            <span class="track-badge" data-track="keynote">Keynote</span>
+            <span class="legend-desc">Featured keynote speakers</span>
+          </div>
+          <div class="legend-item">
+            <span class="track-badge" data-track="plenary">Plenary</span>
+            <span class="legend-desc">Full-audience sessions (lightning talks, opening/closing)</span>
+          </div>
+          <div class="legend-item">
+            <span class="track-badge" data-track="charla">Charla</span>
+            <span class="legend-desc">Talks presented in Spanish</span>
+          </div>
+          <div class="legend-item">
+            <span class="track-badge" data-track="lightning-talks">Lightning Talks</span>
+            <span class="legend-desc">Short 5-minute presentations</span>
+          </div>
+          <div class="legend-item">
+            <span class="track-badge" data-track="ai">AI</span>
+            <span class="legend-desc">Future of AI with Python track</span>
+          </div>
+          <div class="legend-item">
+            <span class="track-badge" data-track="security">Security</span>
+            <span class="legend-desc">Trailblazing Python Security track</span>
+          </div>
+          <div class="legend-item">
+            <span class="track-badge" data-track="poster">Poster</span>
+            <span class="legend-desc">Poster session presentations</span>
+          </div>
+          <div class="legend-item">
+            <span class="track-badge" data-track="sponsor presentation">Sponsor Presentation</span>
+            <span class="legend-desc">Talks by conference sponsors</span>
+          </div>
+          <div class="legend-item">
+            <span class="track-badge" data-track="open space">Open Space</span>
+            <span class="legend-desc">Attendee-organized unconference sessions</span>
+          </div>
+        </div>
+      </ion-col>
+    </ion-row>
+
+    <ion-row>
       <br>
       <br>
       <br>

--- a/src/app/pages/about-pycon/about-pycon.page.scss
+++ b/src/app/pages/about-pycon/about-pycon.page.scss
@@ -1,0 +1,35 @@
+.legend-heading {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-top: 1.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.legend-intro {
+  font-size: 0.875rem;
+  color: var(--ion-color-medium);
+  margin-bottom: 1rem;
+}
+
+.legend-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.legend-item .track-badge {
+  flex-shrink: 0;
+  min-width: 5.5rem;
+  text-align: center;
+}
+
+.legend-desc {
+  font-size: 0.875rem;
+  color: var(--ion-text-color);
+}


### PR DESCRIPTION
## Summary
- Adds a "Session Types" legend section to the About PyCon US page between CMS content and version info
- Each session type is shown with its actual colored `.track-badge` pill (matching the schedule view) and a brief description
- Helps first-time attendees understand what each track color/label means

Closes PYMOBIL-70

## Test plan
- [ ] Open the About PyCon US page and verify the legend appears between the CMS content and version info
- [ ] Confirm each badge color matches the corresponding badge in the schedule view
- [ ] Check layout on both mobile and tablet viewports
- [ ] Verify dark mode renders correctly (badges use `--ion-text-color` and `--ion-color-medium`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)