### PR TITLE
Reorganize sidebar navigation categories

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -86,9 +86,33 @@
           </ion-accordion-group>
 
           <ion-list-header>
+            Events
+          </ion-list-header>
+          <ion-menu-toggle autoHide="false" *ngFor="let p of conferencePages; let i = index">
+            <ion-item [routerLink]="p.url" routerLinkActive="selected" routerDirection="root" detail="false">
+              <ion-icon slot="start" [name]="p.icon"></ion-icon>
+              <ion-label>
+                {{p.title}}
+              </ion-label>
+            </ion-item>
+          </ion-menu-toggle>
+
+          <ion-list-header>
+            Expo &amp; Sponsors
+          </ion-list-header>
+          <ion-menu-toggle autoHide="false" *ngFor="let p of expoPages; let i = index">
+            <ion-item [routerLink]="p.url" routerLinkActive="selected" routerDirection="root" detail="false">
+              <ion-icon slot="start" [name]="p.icon"></ion-icon>
+              <ion-label>
+                {{p.title}}
+              </ion-label>
+            </ion-item>
+          </ion-menu-toggle>
+
+          <ion-list-header>
             Information
           </ion-list-header>
-          <ion-menu-toggle autoHide="false" *ngFor="let p of appPages; let i = index">
+          <ion-menu-toggle autoHide="false" *ngFor="let p of infoPages; let i = index">
             <ion-item [routerLink]="p.url" routerLinkActive="selected" routerDirection="root" detail="false">
               <ion-icon slot="start" [name]="p.icon"></ion-icon>
               <ion-label>
@@ -96,7 +120,6 @@
               </ion-label>
               <ion-badge *ngIf="(p.title === 'About PyCon US' && liveUpdateService.needsUpdate)">Live Update Available</ion-badge>
             </ion-item>
-
           </ion-menu-toggle>
 
         </ion-list>
@@ -117,13 +140,6 @@
             <ion-item routerLink="/app/tabs/login" routerLinkActive="active" routerDirection="root" detail="false">
               <ion-icon slot="start" name="log-in"></ion-icon>
               <ion-label>Login</ion-label>
-            </ion-item>
-          </ion-menu-toggle>
-
-          <ion-menu-toggle autoHide="false">
-            <ion-item routerLink="/app/tabs/help" routerLinkActive="active" routerDirection="root" detail="false">
-              <ion-icon slot="start" name="help-circle-outline"></ion-icon>
-              <ion-label>Help & Safety</ion-label>
             </ion-item>
           </ion-menu-toggle>
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -33,16 +33,21 @@ export class AppComponent implements OnInit {
     { title: 'Posters',   group: 'presentations', url: '/app/tabs/tracks/posters',   icon: 'easel-outline'},
     { title: 'Sponsor Presentations', url: '/app/tabs/tracks/sponsor-presentations', icon: 'briefcase-outline'},
   ]
-  appPages = [
-    { title: 'About PyCon US', url: '/app/tabs/about-pycon', icon: 'information-circle-outline' },
-    { title: 'About The PSF', url: '/app/tabs/about-psf', icon: 'logo-python' },
-    { title: 'Conference Map', url: '/app/tabs/conference-map', icon:'map-outline' },
-    { title: 'Social', url: '/app/tabs/social-media', icon: 'chatbubbles-outline' },
+  conferencePages = [
     { title: 'Open Spaces', url: '/app/tabs/tracks/open-spaces', icon: 'people-circle-outline' },
     { title: 'Sprints', url: '/app/tabs/sprints', icon: 'rocket-outline' },
-    { title: 'Job Listings', url: '/app/tabs/job-listings', icon: 'briefcase-outline' },
+  ]
+  expoPages = [
     { title: 'Sponsors', url: '/app/tabs/sponsors', icon: 'business-outline' },
     { title: 'Expo Hall', url: '/app/tabs/expo-hall', icon: 'storefront-outline' },
+    { title: 'Job Listings', url: '/app/tabs/job-listings', icon: 'briefcase-outline' },
+  ]
+  infoPages = [
+    { title: 'About PyCon US', url: '/app/tabs/about-pycon', icon: 'information-circle-outline' },
+    { title: 'About The PSF', url: '/app/tabs/about-psf', icon: 'logo-python' },
+    { title: 'Social', url: '/app/tabs/social-media', icon: 'chatbubbles-outline' },
+    { title: 'Conference Map', url: '/app/tabs/conference-map', icon: 'map-outline' },
+    { title: 'Help & Safety', url: '/app/tabs/help', icon: 'help-circle-outline' },
   ]
   nickname = null;
   loggedIn = false;


### PR DESCRIPTION
## Summary
- Splits the monolithic "Information" sidebar section into three logical groups:
  - **Events** — Open Spaces, Sprints (summits will be added here later)
  - **Expo & Sponsors** — Sponsors, Expo Hall, Job Listings
  - **Information** — About PyCon US, About The PSF, Social, Conference Map, Help & Safety
- Moves Help & Safety from Account section into Information

## Test plan
- [ ] Verify all sidebar links navigate to correct pages
- [ ] Check sidebar renders correctly in light and dark mode
- [ ] Verify live update badge still shows on About PyCon US
<img width="207" height="721" alt="image" src="https://github.com/user-attachments/assets/460bcab1-f746-4762-873f-aa411d173753" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)