### PR TITLE
Redesign social media page

### DIFF
--- a/src/app/pages/social-media/social-media.page.html
+++ b/src/app/pages/social-media/social-media.page.html
@@ -9,21 +9,114 @@
 </ion-header>
 
 <ion-content>
+  <div class="hashtag-banner">
+    <ion-chip color="primary" outline="true">
+      <ion-icon name="pricetag-outline"></ion-icon>
+      <ion-label><strong>#PyConUS</strong></ion-label>
+    </ion-chip>
+    <ion-chip color="primary" outline="true">
+      <ion-icon name="pricetag-outline"></ion-icon>
+      <ion-label><strong>#PyConUS2026</strong></ion-label>
+    </ion-chip>
+  </div>
 
-  <ion-grid>
-    <ion-row>
-     <ion-col>
-      <ion-row>
-        <ion-col [innerHtml]="content['social-media']">
-        </ion-col>
-      </ion-row>
-    </ion-col>
-    </ion-row>
-    <ion-row>
-      <br>
-      <br>
-      <br>
-      <br>
-    </ion-row>
-  </ion-grid>
+  <ion-list lines="full">
+    <ion-list-header>
+      <ion-label>PyCon US</ion-label>
+    </ion-list-header>
+
+    <ion-item button="true" (click)="openUrl('https://fosstodon.org/@pycon')" detail="true">
+      <ion-icon slot="start" name="logo-mastodon" color="primary"></ion-icon>
+      <ion-label>
+        <h2>Mastodon</h2>
+        <p>&#64;pycon&#64;fosstodon.org</p>
+      </ion-label>
+    </ion-item>
+
+    <ion-item button="true" (click)="openUrl('https://x.com/pycon')" detail="true">
+      <ion-icon slot="start" name="logo-twitter" color="primary"></ion-icon>
+      <ion-label>
+        <h2>X / Twitter</h2>
+        <p>&#64;pycon</p>
+      </ion-label>
+    </ion-item>
+
+    <ion-item button="true" (click)="openUrl('https://www.youtube.com/@PyConUS')" detail="true">
+      <ion-icon slot="start" name="logo-youtube" color="danger"></ion-icon>
+      <ion-label>
+        <h2>YouTube</h2>
+        <p>PyCon US</p>
+      </ion-label>
+    </ion-item>
+
+    <ion-item button="true" (click)="openUrl('https://www.linkedin.com/company/thepsf/')" detail="true">
+      <ion-icon slot="start" name="logo-linkedin" color="primary"></ion-icon>
+      <ion-label>
+        <h2>LinkedIn</h2>
+        <p>Python Software Foundation</p>
+      </ion-label>
+    </ion-item>
+  </ion-list>
+
+  <ion-list lines="full">
+    <ion-list-header>
+      <ion-label>Python Software Foundation</ion-label>
+    </ion-list-header>
+
+    <ion-item button="true" (click)="openUrl('https://fosstodon.org/@ThePSF')" detail="true">
+      <ion-icon slot="start" name="logo-mastodon" color="primary"></ion-icon>
+      <ion-label>
+        <h2>Mastodon</h2>
+        <p>&#64;ThePSF&#64;fosstodon.org</p>
+      </ion-label>
+    </ion-item>
+
+    <ion-item button="true" (click)="openUrl('https://x.com/ThePSF')" detail="true">
+      <ion-icon slot="start" name="logo-twitter" color="primary"></ion-icon>
+      <ion-label>
+        <h2>X / Twitter</h2>
+        <p>&#64;ThePSF</p>
+      </ion-label>
+    </ion-item>
+  </ion-list>
+
+  <ion-list lines="full">
+    <ion-list-header>
+      <ion-label>Blogs</ion-label>
+    </ion-list-header>
+
+    <ion-item button="true" (click)="openUrl('https://pycon.blogspot.com')" detail="true">
+      <ion-icon slot="start" name="calendar-outline" color="primary"></ion-icon>
+      <ion-label>
+        <h2>PyCon US Blog</h2>
+        <p>Conference news and announcements</p>
+      </ion-label>
+    </ion-item>
+
+    <ion-item button="true" (click)="openUrl('https://pyfound.blogspot.com')" detail="true">
+      <ion-icon slot="start" name="newspaper-outline" color="primary"></ion-icon>
+      <ion-label>
+        <h2>PSF Blog</h2>
+        <p>News and updates from the Python Software Foundation</p>
+      </ion-label>
+    </ion-item>
+
+    <ion-item button="true" (click)="openUrl('https://blog.python.org')" detail="true">
+      <ion-icon slot="start" name="logo-python" color="primary"></ion-icon>
+      <ion-label>
+        <h2>CPython Blog</h2>
+        <p>Python insider — core development updates</p>
+      </ion-label>
+    </ion-item>
+
+    <ion-item button="true" (click)="openUrl('https://blog.pypi.org')" detail="true">
+      <ion-icon slot="start" name="cube-outline" color="primary"></ion-icon>
+      <ion-label>
+        <h2>PyPI Blog</h2>
+        <p>News from the Python Package Index</p>
+      </ion-label>
+    </ion-item>
+  </ion-list>
+
+  <div style="height: 80px"></div>
 </ion-content>

--- a/src/app/pages/social-media/social-media.page.scss
+++ b/src/app/pages/social-media/social-media.page.scss
@@ -1,0 +1,6 @@
+.hashtag-banner {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  padding: 16px 16px 8px;
+}

--- a/src/app/pages/social-media/social-media.page.ts
+++ b/src/app/pages/social-media/social-media.page.ts
@@ -1,7 +1,4 @@
-import { Component, OnInit, ChangeDetectorRef } from '@angular/core';
-import { LoadingController } from '@ionic/angular';
-
-import { ConferenceData } from '../../providers/conference-data';
+import { Component } from '@angular/core';
 import { LiveUpdateService } from '../../providers/live-update.service';
 
 @Component({
@@ -9,31 +6,12 @@ import { LiveUpdateService } from '../../providers/live-update.service';
   templateUrl: './social-media.page.html',
   styleUrls: ['./social-media.page.scss'],
 })
-export class SocialMediaPage implements OnInit {
-  content: any = "";
-
+export class SocialMediaPage {
   constructor(
-    private loadingCtrl: LoadingController,
-    private confData: ConferenceData,
-    private changeDetection: ChangeDetectorRef,
     public liveUpdateService: LiveUpdateService,
   ) {}
 
-  reloadContent() {
-    this.loadingCtrl.create({
-      message: 'Fetching latest...',
-      duration: 10000,
-    }).then((loader) => {
-      loader.present();
-      this.confData.getContent().subscribe((content: any[]) => {
-        this.content = content;
-        this.changeDetection.detectChanges();
-        setTimeout(() => {loader.dismiss()}, 100);
-      });
-    });
-  }
-
-  ngOnInit() {
-    this.reloadContent();
+  openUrl(url: string) {
+    window.open(url, '_system', 'location=yes');
   }
 }


### PR DESCRIPTION
## Summary
- Replaces blank social media page with structured content
- Hashtag banner with #PyConUS and #PyConUS2026
- PyCon US section: Mastodon, X/Twitter, YouTube, LinkedIn (PSF account)
- PSF section: Mastodon, X/Twitter
- Blogs section: PyCon US Blog, PSF Blog, CPython Blog, PyPI Blog
- Removed Flickr (not our account) and fixed LinkedIn URL to PSF page

## Test plan
- [ ] Verify all links open in system browser
- [ ] Check light and dark mode
- [ ] Verify hashtag chips render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)