### PR TITLE
Add Lightning Talks sign-up page

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -35,6 +35,7 @@ export class AppComponent implements OnInit {
   ]
   conferencePages = [
     { title: 'Open Spaces', url: '/app/tabs/tracks/open-spaces', icon: 'people-circle-outline' },
+    { title: 'Lightning Talks', url: '/app/tabs/lightning-talks', icon: 'flash-outline' },
     { title: 'Sprints', url: '/app/tabs/sprints', icon: 'rocket-outline' },
   ]
   expoPages = [

--- a/src/app/pages/lightning-talks/lightning-talks-routing.module.ts
+++ b/src/app/pages/lightning-talks/lightning-talks-routing.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { LightningTalksPage } from './lightning-talks.page';
+
+const routes: Routes = [{ path: '', component: LightningTalksPage }];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class LightningTalksPageRoutingModule {}

--- a/src/app/pages/lightning-talks/lightning-talks.module.ts
+++ b/src/app/pages/lightning-talks/lightning-talks.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+import { LightningTalksPageRoutingModule } from './lightning-talks-routing.module';
+import { LightningTalksPage } from './lightning-talks.page';
+
+@NgModule({
+  imports: [CommonModule, IonicModule, LightningTalksPageRoutingModule],
+  declarations: [LightningTalksPage]
+})
+export class LightningTalksPageModule {}

--- a/src/app/pages/lightning-talks/lightning-talks.page.html
+++ b/src/app/pages/lightning-talks/lightning-talks.page.html
@@ -12,59 +12,85 @@
   <div class="lt-hero">
     <ion-icon name="flash" class="lt-hero-icon"></ion-icon>
     <h1>Lightning Talks</h1>
-    <p>5 minutes. Any topic. Your moment to shine.</p>
+    <p>5 minutes. Any topic. Your moment.</p>
   </div>
 
   <ion-card class="lt-card">
     <ion-card-content>
+      <h2>What's a Lightning Talk?</h2>
       <p>
-        Lightning talks are short presentations given during plenary sessions.
-        Anyone can sign up — first-time speakers, seasoned pros, and everyone in between.
+        A maximum of 5 minutes on any topic of interest to other Python people.
+        It doesn't have to be about something you wrote — it can be something you learned,
+        or a technique you think other people will be interested in.
       </p>
+      <p>
+        You know that thing at work that everyone comes to you for help with? <strong>Talk about that!</strong>
+      </p>
+      <p>
+        You know that thing you just learned that helped you out? <strong>Talk about that!</strong>
+      </p>
+      <p>
+        You know that thing you always wish you understood, but haven't figured out yet? <strong>Talk about that!</strong>
+      </p>
+      <p>Slides are encouraged but not required!</p>
+
       <ion-button expand="block" color="primary" (click)="signUp()">
         <ion-icon slot="start" name="create-outline"></ion-icon>
-        Sign Up for Lightning Talks
+        Sign Up for a Lightning Talk
       </ion-button>
     </ion-card-content>
   </ion-card>
 
-  <ion-card class="tips-card">
+  <ion-card class="encourage-card">
     <ion-card-header>
-      <ion-card-title>Tips</ion-card-title>
+      <ion-card-title>Think you can't do one?</ion-card-title>
     </ion-card-header>
     <ion-card-content>
       <ion-list lines="none">
         <ion-item>
-          <ion-icon slot="start" name="timer-outline" color="primary"></ion-icon>
+          <ion-icon slot="start" name="school-outline" color="primary"></ion-icon>
           <ion-label class="ion-text-wrap">
-            <strong>5 minutes max</strong>
-            <p>You will be cut off — practice your timing!</p>
+            <strong>"Everyone already knows that"</strong>
+            <p>No, they don't. Even if they do, it's interesting to hear your explanation.</p>
           </ion-label>
         </ion-item>
         <ion-item>
-          <ion-icon slot="start" name="chatbubble-outline" color="primary"></ion-icon>
+          <ion-icon slot="start" name="bulb-outline" color="primary"></ion-icon>
           <ion-label class="ion-text-wrap">
-            <strong>No Q&A</strong>
-            <p>Catch the speaker in the hallway afterwards</p>
+            <strong>"I'm not an expert at anything"</strong>
+            <p>You don't have to be an expert, just interested enough to talk for 5 minutes. You can even do 1 minute!</p>
           </ion-label>
         </ion-item>
         <ion-item>
-          <ion-icon slot="start" name="easel-outline" color="primary"></ion-icon>
+          <ion-icon slot="start" name="heart-outline" color="primary"></ion-icon>
           <ion-label class="ion-text-wrap">
-            <strong>Slides optional</strong>
-            <p>Live demos, stories, and rants all welcome</p>
+            <strong>"It's scary talking in front of people"</strong>
+            <p>Folks at PyCon US are super-friendly and always welcoming of new speakers. Everyone is nervous — even people you think aren't.</p>
           </ion-label>
         </ion-item>
         <ion-item>
-          <ion-icon slot="start" name="happy-outline" color="primary"></ion-icon>
+          <ion-icon slot="start" name="sparkles-outline" color="primary"></ion-icon>
           <ion-label class="ion-text-wrap">
-            <strong>Have fun</strong>
-            <p>The audience is on your side — go for it!</p>
+            <strong>"My idea isn't good enough"</strong>
+            <p>It's a better idea than you think. Are there really any bad ideas for lightning talks? :)</p>
           </ion-label>
         </ion-item>
       </ion-list>
     </ion-card-content>
   </ion-card>
+
+  <ion-list lines="full">
+    <ion-list-header>
+      <ion-label>More Info</ion-label>
+    </ion-list-header>
+    <ion-item button="true" (click)="openUrl('https://us.pycon.org/2026/events/lightning-talks/')" detail="true">
+      <ion-icon slot="start" name="globe-outline" color="primary"></ion-icon>
+      <ion-label>
+        <h2>Lightning Talks on pycon.org</h2>
+        <p>Full details, schedule, and sign-up</p>
+      </ion-label>
+    </ion-item>
+  </ion-list>
 
   <div style="height: 80px"></div>
 </ion-content>

--- a/src/app/pages/lightning-talks/lightning-talks.page.html
+++ b/src/app/pages/lightning-talks/lightning-talks.page.html
@@ -1,0 +1,70 @@
+<ion-header class="ion-no-border">
+  <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-menu-button [color]="liveUpdateService.needsUpdate ? 'primary' : 'medium'"></ion-menu-button>
+      <ion-badge *ngIf="liveUpdateService.needsUpdate" size=sm>1</ion-badge>
+    </ion-buttons>
+    <ion-title>Lightning Talks</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <div class="lt-hero">
+    <ion-icon name="flash" class="lt-hero-icon"></ion-icon>
+    <h1>Lightning Talks</h1>
+    <p>5 minutes. Any topic. Your moment to shine.</p>
+  </div>
+
+  <ion-card class="lt-card">
+    <ion-card-content>
+      <p>
+        Lightning talks are short presentations given during plenary sessions.
+        Anyone can sign up — first-time speakers, seasoned pros, and everyone in between.
+      </p>
+      <ion-button expand="block" color="primary" (click)="signUp()">
+        <ion-icon slot="start" name="create-outline"></ion-icon>
+        Sign Up for Lightning Talks
+      </ion-button>
+    </ion-card-content>
+  </ion-card>
+
+  <ion-card class="tips-card">
+    <ion-card-header>
+      <ion-card-title>Tips</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <ion-list lines="none">
+        <ion-item>
+          <ion-icon slot="start" name="timer-outline" color="primary"></ion-icon>
+          <ion-label class="ion-text-wrap">
+            <strong>5 minutes max</strong>
+            <p>You will be cut off — practice your timing!</p>
+          </ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-icon slot="start" name="chatbubble-outline" color="primary"></ion-icon>
+          <ion-label class="ion-text-wrap">
+            <strong>No Q&A</strong>
+            <p>Catch the speaker in the hallway afterwards</p>
+          </ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-icon slot="start" name="easel-outline" color="primary"></ion-icon>
+          <ion-label class="ion-text-wrap">
+            <strong>Slides optional</strong>
+            <p>Live demos, stories, and rants all welcome</p>
+          </ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-icon slot="start" name="happy-outline" color="primary"></ion-icon>
+          <ion-label class="ion-text-wrap">
+            <strong>Have fun</strong>
+            <p>The audience is on your side — go for it!</p>
+          </ion-label>
+        </ion-item>
+      </ion-list>
+    </ion-card-content>
+  </ion-card>
+
+  <div style="height: 80px"></div>
+</ion-content>

--- a/src/app/pages/lightning-talks/lightning-talks.page.scss
+++ b/src/app/pages/lightning-talks/lightning-talks.page.scss
@@ -37,15 +37,21 @@
     padding: 24px;
   }
 
+  h2 {
+    font-size: 1.15rem;
+    font-weight: 700;
+    margin: 0 0 12px;
+  }
+
   p {
     font-size: 0.95rem;
     line-height: 1.5;
-    margin-bottom: 16px;
+    margin-bottom: 12px;
     color: var(--ion-text-color);
   }
 }
 
-.tips-card {
+.encourage-card {
   margin: 0 20px;
   border-radius: 16px;
 

--- a/src/app/pages/lightning-talks/lightning-talks.page.scss
+++ b/src/app/pages/lightning-talks/lightning-talks.page.scss
@@ -1,0 +1,55 @@
+.lt-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 48px 24px 32px;
+  background: linear-gradient(180deg, #3B3EA9 23.5%, #101136 53.29%);
+  color: #fff;
+  text-align: center;
+
+  .lt-hero-icon {
+    font-size: 56px;
+    color: #FFD779;
+    margin-bottom: 12px;
+  }
+
+  h1 {
+    margin: 0;
+    font-size: 1.6rem;
+    font-weight: 700;
+  }
+
+  p {
+    margin: 8px 0 0;
+    font-size: 0.95rem;
+    opacity: 0.85;
+  }
+}
+
+.lt-card {
+  margin: -16px 20px 16px;
+  border-radius: 16px;
+  box-shadow: 0 8px 32px rgba(16, 17, 54, 0.15);
+  position: relative;
+  z-index: 1;
+
+  ion-card-content {
+    padding: 24px;
+  }
+
+  p {
+    font-size: 0.95rem;
+    line-height: 1.5;
+    margin-bottom: 16px;
+    color: var(--ion-text-color);
+  }
+}
+
+.tips-card {
+  margin: 0 20px;
+  border-radius: 16px;
+
+  ion-card-title {
+    font-size: 1.1rem;
+  }
+}

--- a/src/app/pages/lightning-talks/lightning-talks.page.ts
+++ b/src/app/pages/lightning-talks/lightning-talks.page.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { LiveUpdateService } from '../../providers/live-update.service';
+
+@Component({
+  selector: 'app-lightning-talks',
+  templateUrl: './lightning-talks.page.html',
+  styleUrls: ['./lightning-talks.page.scss'],
+})
+export class LightningTalksPage {
+  constructor(public liveUpdateService: LiveUpdateService) {}
+
+  signUp() {
+    window.open('https://us.pycon.org/2026/events/lightning-talks/', '_system', 'location=yes');
+  }
+}

--- a/src/app/pages/lightning-talks/lightning-talks.page.ts
+++ b/src/app/pages/lightning-talks/lightning-talks.page.ts
@@ -12,4 +12,8 @@ export class LightningTalksPage {
   signUp() {
     window.open('https://us.pycon.org/2026/events/lightning-talks/', '_system', 'location=yes');
   }
+
+  openUrl(url: string) {
+    window.open(url, '_system', 'location=yes');
+  }
 }

--- a/src/app/pages/tabs-page/tabs-page-routing.module.ts
+++ b/src/app/pages/tabs-page/tabs-page-routing.module.ts
@@ -130,6 +130,15 @@ const routes: Routes = [
         ]
       },
       {
+        path: 'lightning-talks',
+        children: [
+          {
+            path: '',
+            loadChildren: () => import('../lightning-talks/lightning-talks.module').then(m => m.LightningTalksPageModule)
+          }
+        ]
+      },
+      {
         path: 'session-types',
         children: [
           {


### PR DESCRIPTION
## Summary
- New Lightning Talks page with PyCon 2026 themed hero, sign-up button, and tips
- Added to Events section in sidebar between Open Spaces and Sprints
- Links to us.pycon.org/2026/events/lightning-talks/ for sign-up

## Test plan
- [ ] Verify Lightning Talks appears in Events sidebar section
- [ ] Verify sign-up button opens correct URL in system browser
- [ ] Check light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)