### PR TITLE
Add consent confirmation before lead retrieval scanning

### DIFF
--- a/src/app/pages/map/map.ts
+++ b/src/app/pages/map/map.ts
@@ -243,6 +243,9 @@ export class MapPage implements OnInit, OnDestroy {
     this.refresh_presentation();
     setTimeout(this.syncAllPending, 60000);
 
+    // Show consent dialog on first use
+    await this.showConsentDialog();
+
     // Check if this is a staff user (has door_check but not lead_retrieval)
     const hasLeadRetrieval = await this.userData.checkHasLeadRetrieval();
     const hasDoorCheck = await this.userData.checkHasDoorCheck();
@@ -250,6 +253,36 @@ export class MapPage implements OnInit, OnDestroy {
       this.isStaffScanner = true;
       this.showSponsorSelector();
     }
+  }
+
+  async showConsentDialog() {
+    const hasConsent = await this.userData.checkScannerConsent();
+    if (hasConsent) return;
+
+    const alert = await this.alertCtrl.create({
+      header: 'Lead Scanner Consent',
+      message: 'By using the lead scanner, you confirm that you will only scan badges of attendees who have given you explicit verbal permission. Scanning without consent violates the PyCon US Code of Conduct.',
+      backdropDismiss: false,
+      buttons: [
+        {
+          text: 'Cancel',
+          role: 'cancel',
+          handler: () => {
+            // Disable scanning — user didn't consent
+            this.scan_start_button_visibility = 'hidden';
+          },
+        },
+        {
+          text: 'I Agree',
+          handler: () => {
+            this.userData.setScannerConsent(true);
+          },
+        },
+      ],
+    });
+    await alert.present();
+    // Wait for dismissal before continuing
+    await alert.onDidDismiss();
   }
 
   async showSponsorSelector() {

--- a/src/app/providers/user-data.ts
+++ b/src/app/providers/user-data.ts
@@ -20,6 +20,7 @@ export class UserData {
   HAS_DOOR_CHECK = 'hasDoorCheck';
   HAS_MASK_VIOLATION = 'hasMaskViolation';
   IS_SPEAKER = 'isSpeaker';
+  HAS_SCANNER_CONSENT = 'hasScannerConsent';
 
   constructor(
     public storage: Storage,
@@ -168,6 +169,7 @@ export class UserData {
       this.storage.remove(this.HAS_DOOR_CHECK);
       this.storage.remove(this.HAS_MASK_VIOLATION);
       this.storage.remove(this.IS_SPEAKER);
+      this.storage.remove(this.HAS_SCANNER_CONSENT);
     }).then(() => {
       window.dispatchEvent(new CustomEvent('user:logout'));
     });
@@ -252,6 +254,16 @@ export class UserData {
   checkHasMaskViolation(): Promise<boolean> {
     return this.storage.get(this.HAS_MASK_VIOLATION).then((value) => {
       return value;
+    });
+  }
+
+  setScannerConsent(value: boolean): Promise<any> {
+    return this.storage.set(this.HAS_SCANNER_CONSENT, value);
+  }
+
+  checkScannerConsent(): Promise<boolean> {
+    return this.storage.get(this.HAS_SCANNER_CONSENT).then((value) => {
+      return value === true;
     });
   }
 


### PR DESCRIPTION
## Summary
Shows a Code of Conduct consent dialog the first time a user opens the lead scanner.

- Must agree to only scan badges with explicit verbal permission
- "I Agree" stores consent, proceeds to scanner
- "Cancel" disables the scan button
- Consent resets on logout (re-shown next session)
- Non-dismissable (can't tap outside to skip)

## Test plan
- [ ] First time opening scanner shows consent dialog
- [ ] Agreeing lets you scan, dialog doesn't reappear
- [ ] Canceling hides the scan button
- [ ] Logging out and back in resets consent

🤖 Generated with [Claude Code](https://claude.com/claude-code)