### PR TITLE
Lead Scanner - Allow staff to scan for any sponsor, rework UI, Dev tools

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -8,6 +8,13 @@
             PyCon US 2026
           </ion-list-header>
 
+          <ion-menu-toggle *ngIf="isDev" autoHide="false">
+            <ion-item routerLink="/app/tabs/dev-tools" routerLinkActive="active" routerDirection="root" detail="false" color="warning">
+              <ion-icon slot="start" name="construct-outline"></ion-icon>
+              <ion-label>Dev Tools</ion-label>
+            </ion-item>
+          </ion-menu-toggle>
+
           <ion-item *ngIf="loggedIn">
             <ion-label>Hello, {{nickname}}</ion-label>
           </ion-item>
@@ -43,7 +50,7 @@
             </ion-item>
           </ion-menu-toggle>
 
-          <ion-menu-toggle *ngIf="hasLeadRetrieval" autoHide="false">
+          <ion-menu-toggle *ngIf="hasLeadRetrieval || hasDoorCheck" autoHide="false">
             <ion-item routerLink="/app/tabs/lead-retrieval" routerLinkActive="active" routerDirection="root" detail="false">
               <ion-icon slot="start" name="qr-code"></ion-icon>
               <ion-label>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,6 +10,7 @@ import { Storage } from '@ionic/storage-angular';
 import { UserData } from './providers/user-data';
 import { ConferenceData } from './providers/conference-data';
 import { LiveUpdateService } from './providers/live-update.service';
+import { environment } from '../environments/environment';
 
 @Component({
   selector: 'app-root',
@@ -67,6 +68,8 @@ export class AppComponent implements OnInit {
   hasLeadRetrieval = false;
   hasDoorCheck= false;
   hasMaskViolation = false;
+  isDev = !environment.production;
+  environmentUrl = environment.baseUrl;
 
   constructor(
     private menu: MenuController,
@@ -215,4 +218,5 @@ export class AppComponent implements OnInit {
   openUrl(url: string) {
     window.open(url, '_system', 'location=yes');
   }
+
 }

--- a/src/app/pages/dev-tools/dev-tools-routing.module.ts
+++ b/src/app/pages/dev-tools/dev-tools-routing.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { DevToolsPage } from './dev-tools.page';
+
+const routes: Routes = [{ path: '', component: DevToolsPage }];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class DevToolsPageRoutingModule {}

--- a/src/app/pages/dev-tools/dev-tools.module.ts
+++ b/src/app/pages/dev-tools/dev-tools.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+import { DevToolsPageRoutingModule } from './dev-tools-routing.module';
+import { DevToolsPage } from './dev-tools.page';
+
+@NgModule({
+  imports: [CommonModule, IonicModule, DevToolsPageRoutingModule],
+  declarations: [DevToolsPage]
+})
+export class DevToolsPageModule {}

--- a/src/app/pages/dev-tools/dev-tools.page.html
+++ b/src/app/pages/dev-tools/dev-tools.page.html
@@ -1,0 +1,100 @@
+<ion-header class="ion-no-border">
+  <ion-toolbar color="warning">
+    <ion-buttons slot="start">
+      <ion-menu-button></ion-menu-button>
+    </ion-buttons>
+    <ion-title>Dev Tools</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <ion-card>
+    <ion-card-header>
+      <ion-card-title>Environment</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <ion-list lines="none">
+        <ion-item>
+          <ion-label>
+            <p>Name</p>
+            <h3>{{env.name}}</h3>
+          </ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-label>
+            <p>API Base URL</p>
+            <h3 style="font-family: monospace; font-size: 0.85rem;">{{env.baseUrl}}</h3>
+          </ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-label>
+            <p>Timezone</p>
+            <h3>{{env.timezone}}</h3>
+          </ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-label>
+            <p>Production</p>
+            <h3>{{env.production}}</h3>
+          </ion-label>
+        </ion-item>
+      </ion-list>
+    </ion-card-content>
+  </ion-card>
+
+  <ion-card>
+    <ion-card-header>
+      <ion-card-title>Storage</ion-card-title>
+      <ion-card-subtitle>{{storageCount}} keys | {{scanCount}} scans</ion-card-subtitle>
+    </ion-card-header>
+    <ion-card-content>
+      <ion-button expand="block" fill="outline" color="medium" (click)="dumpStorage()">
+        <ion-icon slot="start" name="code-outline"></ion-icon>
+        Dump Storage to Console
+      </ion-button>
+    </ion-card-content>
+  </ion-card>
+
+  <ion-card>
+    <ion-card-header>
+      <ion-card-title>Actions</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <ion-list lines="none">
+        <ion-item button="true" (click)="clearScanData()" detail="false">
+          <ion-icon slot="start" name="trash-outline" color="warning"></ion-icon>
+          <ion-label>
+            <h2>Clear Scan Data</h2>
+            <p>Remove all scans, notes, consent, sponsor selection</p>
+          </ion-label>
+        </ion-item>
+
+        <ion-item button="true" (click)="invalidateCache()" detail="false">
+          <ion-icon slot="start" name="refresh-outline" color="warning"></ion-icon>
+          <ion-label>
+            <h2>Invalidate Schedule Cache</h2>
+            <p>Force re-fetch of conference.json on next load</p>
+          </ion-label>
+        </ion-item>
+
+        <ion-item button="true" (click)="nukeStorage()" detail="false">
+          <ion-icon slot="start" name="nuclear-outline" color="danger"></ion-icon>
+          <ion-label>
+            <h2>Nuke All Storage</h2>
+            <p>Wipe everything and reload — you will be logged out</p>
+          </ion-label>
+        </ion-item>
+
+        <ion-item button="true" (click)="refreshStats()" detail="false">
+          <ion-icon slot="start" name="analytics-outline" color="primary"></ion-icon>
+          <ion-label>
+            <h2>Refresh Stats</h2>
+            <p>Update storage key counts</p>
+          </ion-label>
+        </ion-item>
+      </ion-list>
+    </ion-card-content>
+  </ion-card>
+
+  <div style="height: 80px"></div>
+</ion-content>

--- a/src/app/pages/dev-tools/dev-tools.page.scss
+++ b/src/app/pages/dev-tools/dev-tools.page.scss
@@ -1,0 +1,1 @@
+/* Minimal — uses Ionic defaults */

--- a/src/app/pages/dev-tools/dev-tools.page.ts
+++ b/src/app/pages/dev-tools/dev-tools.page.ts
@@ -1,0 +1,82 @@
+import { Component } from '@angular/core';
+import { Storage } from '@ionic/storage-angular';
+import { ToastController } from '@ionic/angular';
+import { ConferenceData } from '../../providers/conference-data';
+import { environment } from '../../../environments/environment';
+
+@Component({
+  selector: 'app-dev-tools',
+  templateUrl: './dev-tools.page.html',
+  styleUrls: ['./dev-tools.page.scss'],
+})
+export class DevToolsPage {
+  env = environment;
+  storageKeys: string[] = [];
+  storageCount = 0;
+  scanCount = 0;
+
+  constructor(
+    private storage: Storage,
+    private toastCtrl: ToastController,
+    private confData: ConferenceData,
+  ) {}
+
+  async ionViewWillEnter() {
+    await this.refreshStats();
+  }
+
+  async refreshStats() {
+    const keys = await this.storage.keys();
+    this.storageKeys = keys;
+    this.storageCount = keys.length;
+    this.scanCount = keys.filter(k =>
+      k.startsWith('pending-scan-') || k.startsWith('synced-scan-') || k.startsWith('failed-scan-')
+    ).length;
+  }
+
+  async clearScanData() {
+    const keys = await this.storage.keys();
+    let cleared = 0;
+    for (const key of keys) {
+      if (key.startsWith('pending-scan-') || key.startsWith('synced-scan-') || key.startsWith('failed-scan-') ||
+          key.startsWith('pending-note-') || key.startsWith('note-') ||
+          key === 'staff-sponsor-id' || key === 'staff-sponsor-name' || key === 'hasScannerConsent') {
+        await this.storage.remove(key);
+        cleared++;
+      }
+    }
+    await this.showToast(`Cleared ${cleared} scan entries`);
+    await this.refreshStats();
+  }
+
+  async invalidateCache() {
+    this.confData.invalidateCache();
+    await this.showToast('Schedule cache invalidated — pull to refresh');
+    await this.refreshStats();
+  }
+
+  async nukeStorage() {
+    await this.storage.clear();
+    await this.showToast('All storage wiped — reloading...');
+    setTimeout(() => window.location.reload(), 500);
+  }
+
+  async dumpStorage() {
+    const dump: any = {};
+    await this.storage.forEach((value, key) => {
+      dump[key] = typeof value === 'object' ? JSON.stringify(value).substring(0, 100) : String(value);
+    });
+    console.table(dump);
+    await this.showToast('Storage dumped to console (open DevTools)');
+  }
+
+  private async showToast(message: string) {
+    const toast = await this.toastCtrl.create({
+      message,
+      duration: 2000,
+      position: 'bottom',
+      color: 'dark',
+    });
+    toast.present();
+  }
+}

--- a/src/app/pages/map/map.html
+++ b/src/app/pages/map/map.html
@@ -1,8 +1,7 @@
-<ion-header>
+<ion-header class="ion-no-border">
   <ion-toolbar>
     <ion-buttons slot="start">
-      <ion-menu-button [color]="liveUpdateService.needsUpdate ? 'primary' : 'medium'"></ion-menu-button>
-      <ion-badge *ngIf="liveUpdateService.needsUpdate" size=sm>1</ion-badge>
+      <ion-menu-button></ion-menu-button>
     </ion-buttons>
     <ion-title>Lead Scanner</ion-title>
   </ion-toolbar>
@@ -13,120 +12,95 @@
     <ion-refresher-content></ion-refresher-content>
   </ion-refresher>
 
-  <ion-item *ngIf="isStaffScanner && selectedSponsor" color="primary" button="true" (click)="showSponsorSelector()">
-    <ion-icon slot="start" name="business-outline"></ion-icon>
-    <ion-label>
-      <h2>Scanning for: {{ selectedSponsor.name }}</h2>
-      <p>Tap to change sponsor</p>
-    </ion-label>
-    <ion-icon slot="end" name="swap-horizontal-outline"></ion-icon>
-  </ion-item>
+  <!-- Staff sponsor selector banner -->
+  <div *ngIf="isStaffScanner && selectedSponsor" class="sponsor-banner">
+    <div class="sponsor-banner-main" (click)="showSponsorSelector()">
+      <img *ngIf="selectedSponsor.logo_url" [src]="selectedSponsor.logo_url" class="sponsor-banner-logo" />
+      <ion-icon *ngIf="!selectedSponsor.logo_url" name="business" class="sponsor-banner-icon"></ion-icon>
+      <div class="sponsor-banner-text">
+        <strong>{{ selectedSponsor.name }}</strong>
+        <span>Tap to change</span>
+      </div>
+      <ion-icon name="chevron-forward-outline" class="sponsor-banner-chevron"></ion-icon>
+    </div>
+    <div class="sponsor-banner-filter" (click)="filterBySponsor = !filterBySponsor; toggleSponsorFilter()">
+      <ion-icon [name]="filterBySponsor ? 'funnel' : 'funnel-outline'" [class.active]="filterBySponsor"></ion-icon>
+    </div>
+  </div>
 
-  <ion-item *ngIf="isStaffScanner && !selectedSponsor" color="warning">
-    <ion-icon slot="start" name="alert-circle-outline"></ion-icon>
-    <ion-label class="ion-text-wrap">
-      <h2>No sponsor selected</h2>
-      <p>Select a sponsor before scanning</p>
-    </ion-label>
-    <ion-button slot="end" fill="clear" (click)="showSponsorSelector()">Select</ion-button>
-  </ion-item>
+  <div *ngIf="isStaffScanner && !selectedSponsor" class="sponsor-banner sponsor-banner-warning" (click)="showSponsorSelector()">
+    <ion-icon name="alert-circle" class="sponsor-banner-icon warning"></ion-icon>
+    <div class="sponsor-banner-text">
+      <strong>No sponsor selected</strong>
+      <span>Tap to select a sponsor</span>
+    </div>
+    <ion-icon name="chevron-forward-outline" class="sponsor-banner-chevron"></ion-icon>
+  </div>
 
-  <ion-list>
-    <ion-list-header>
-      <ion-label>Recent Scans</ion-label>
-    </ion-list-header>
-    <ion-item>
-      <ion-text color="medium" class="header-info">
-        This list displays the recent scans on this device only.<br>
-        View all your scans and the captured data on your dashboard at us.pycon.org.<br>
-      </ion-text>
-    </ion-item>
-    <ion-item *ngIf="show_permissions_error">
-      <ion-card>
-        <ion-card-header>
-          <ion-card-title>Uh oh..</ion-card-title>
-          <ion-card-subtitle>Camera Permissions Not Granted</ion-card-subtitle>
-        </ion-card-header>
-        <ion-card-content>
-          <ion-text>Looks like you did not grant this application permission to access your camera.</ion-text>
-          <ion-text>
-            You can resolve this by opening<br><br>
-            <code *ngIf="ios">Settings > Privacy & Security > Camera > PyCon US 2026<br><br></code>
-            <code *ngIf="!ios">Settings > Apps > PyCon US 2026 > Permissions > Camera<br><br></code>
-            And enabling camera permssions for this app.
-          </ion-text>
-        </ion-card-content>
-      </ion-card>
-    </ion-item>
-    <ion-item *ngFor="let scan of sortScans()">
+  <!-- Camera permission error -->
+  <ion-card *ngIf="show_permissions_error" color="danger" class="permission-card">
+    <ion-card-content>
+      <h3>Camera Permission Required</h3>
+      <p>Open <code *ngIf="ios">Settings > Privacy > Camera > PyCon US</code><code *ngIf="!ios">Settings > Apps > PyCon US > Camera</code> and enable access.</p>
+    </ion-card-content>
+  </ion-card>
+
+
+  <!-- Empty state -->
+  <div *ngIf="sortScans().length === 0" class="empty-state">
+    <ion-icon name="scan-outline" class="empty-icon"></ion-icon>
+    <h3>No scans yet</h3>
+    <p>Tap "Start Scanner" to begin scanning badges</p>
+  </div>
+
+  <!-- Scan list -->
+  <ion-list *ngIf="sortScans().length > 0" lines="full" class="scan-list">
+    <ion-item *ngFor="let scan of sortScans()" class="scan-item" button="true" (click)="openNoteModal(scan.access_code, scan)" detail="false">
+      <div slot="start" class="scan-status-dot" [class.captured]="scan.status === 'captured'" [class.pending]="scan.status === 'pending'" [class.failed]="scan.status === 'failed'"></div>
       <ion-label>
-        <ion-grid>
-          <ion-row>
-            <ion-col size="auto">
-              <h1>
-                <ion-icon
-                  [color]="(scan.status === 'captured')? 'success' : (scan.status === 'failed')? 'danger' : 'default'"
-                  [name]="(scan.status === 'captured')? 'id-card-outline' : 'qr-code'">
-                </ion-icon>
-                {{(scan.status === 'captured')? scan.first_name : scan.access_code}}
-              </h1>
-              <p>Scanned {{scan.scanned_at|dateAgo}}</p>
-              <p *ngIf="scan.status === 'captured'">Captured {{scan.scanned_at|dateAgo}}</p>
-              <p *ngIf="scan.status === 'pending'">Pending capture when online...</p>
-              <p *ngIf="scan.status === 'failed'">Invalid code.</p>
-            </ion-col>
-            <ion-col>
-              <div class="ion-float-end ion-float-top">
-                <ion-button (click)="openNoteModal(scan.access_code, scan)" size="75%" fill="clear">
-                  <ion-icon [name]="scan.note? 'document-text': 'document-outline'"></ion-icon>
-                  <ion-text size="small">Note</ion-text>
-                </ion-button>
-              </div>
-            </ion-col>
-          </ion-row>
-        </ion-grid>
+        <h2 class="scan-name">{{ (scan.status === 'captured') ? scan.first_name : scan.access_code }}</h2>
+        <p *ngIf="isStaffScanner && scan.sponsor_name" class="scan-sponsor">
+          <ion-icon name="business-outline"></ion-icon> {{ scan.sponsor_name }}
+        </p>
+        <p class="scan-time">
+          {{ scan.scanned_at | dateAgo }}
+          <span *ngIf="scan.status === 'pending'" class="scan-badge pending">Pending</span>
+          <span *ngIf="scan.status === 'failed'" class="scan-badge failed">Failed</span>
+        </p>
       </ion-label>
+      <ion-icon slot="end" [name]="scan.note ? 'document-text' : 'document-outline'" [color]="scan.note ? 'primary' : 'medium'" class="scan-note-icon"></ion-icon>
     </ion-item>
   </ion-list>
 </ion-content>
 
 <ion-footer>
-  <ion-card *ngIf="last_scan">
-    <ion-item>
-      <ion-label>
-        <ion-grid>
-          <ion-row>
-            <ion-col>
-              <h1>
-                <ion-icon
-                  [color]="(last_scan.status === 'captured')? 'success' : 'default'"
-                  [name]="(last_scan.status === 'captured')? 'id-card-outline' : 'qr-code'">
-                </ion-icon>
-                {{(last_scan.status === 'captured')? last_scan.first_name : last_scan.access_code}}
-                <ion-spinner *ngIf="last_scan.status !== 'captured'" name="dots"></ion-spinner>
-              </h1>
-            </ion-col>
-            <ion-col>
-              <div class="ion-float-end">
-                <ion-button (click)="openNoteModal(last_scan.access_code, last_scan)" size="75%" fill="clear">
-                  <ion-icon [name]="last_scan.note? 'document-text': 'document-outline'"></ion-icon>
-                  <ion-text size="small">Note</ion-text>
-                </ion-button>
-              </div>
-            </ion-col>
-          </ion-row>
-        </ion-grid>
-      </ion-label>
-    </ion-item>
-  </ion-card>
-  <ion-toolbar class="footer-toolbar">
-    <ion-buttons class="footer-buttons">
-      <ion-button fill="solid" color="success" class="footer-button" (click)="startScan()" [style.visibility]="scan_start_button_visibility" [disabled]="isStaffScanner && !selectedSponsor">
-        Start Scanner!
-      </ion-button>
-      <ion-button fill="solid" color="danger" class="footer-button" (click)="stopScan()" [style.visibility]="scan_stop_button_visibility">
-        Stop Scanner
-      </ion-button>
-    </ion-buttons>
-  </ion-toolbar>
+  <!-- Last scan toast -->
+  <div *ngIf="last_scan" class="last-scan-bar">
+    <div class="last-scan-info">
+      <ion-icon [color]="(last_scan.status === 'captured') ? 'success' : 'medium'" [name]="(last_scan.status === 'captured') ? 'checkmark-circle' : 'ellipsis-horizontal-circle'"></ion-icon>
+      <span class="last-scan-name">
+        {{ (last_scan.status === 'captured') ? last_scan.first_name : last_scan.access_code }}
+        <ion-spinner *ngIf="last_scan.status !== 'captured'" name="dots" class="last-scan-spinner"></ion-spinner>
+      </span>
+    </div>
+    <ion-button fill="clear" size="small" (click)="openNoteModal(last_scan.access_code, last_scan)">
+      <ion-icon [name]="last_scan.note ? 'document-text' : 'document-outline'"></ion-icon>
+    </ion-button>
+  </div>
+
+  <!-- Action buttons -->
+  <div class="scanner-actions">
+    <ion-button *ngIf="isDev" expand="block" fill="clear" size="small" color="medium" (click)="simulateScan()">
+      <ion-icon slot="start" name="flask-outline"></ion-icon>
+      Simulate Scan
+    </ion-button>
+    <ion-button expand="block" color="success" size="large" (click)="startScan()" [style.visibility]="scan_start_button_visibility" [disabled]="isStaffScanner && !selectedSponsor" class="scan-btn-main">
+      <ion-icon slot="start" name="scan-outline"></ion-icon>
+      Start Scanner
+    </ion-button>
+    <ion-button expand="block" color="danger" size="large" (click)="stopScan()" [style.visibility]="scan_stop_button_visibility" class="scan-btn-main">
+      <ion-icon slot="start" name="stop-circle-outline"></ion-icon>
+      Stop Scanner
+    </ion-button>
+  </div>
 </ion-footer>

--- a/src/app/pages/map/map.scss
+++ b/src/app/pages/map/map.scss
@@ -1,20 +1,264 @@
-.footer-buttons {
+ion-header {
+  background: linear-gradient(180deg, #3B3EA9 0%, #3B3EA9 100%);
+  &::after { display: none; }
+}
+
+ion-toolbar {
+  --background: transparent;
+  --border-color: transparent;
+  --color: #ffffff;
+}
+
+ion-toolbar ion-menu-button {
+  --color: #ffffff;
+}
+
+/* Sponsor banner */
+.sponsor-banner {
+  display: flex;
+  align-items: center;
+  background: #3B3EA9;
+  color: #fff;
+
+  &.sponsor-banner-warning {
+    background: linear-gradient(135deg, #e6a817, #c48800);
+  }
+}
+
+.sponsor-banner-main {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 8px 12px 16px;
+  flex: 1;
+  min-width: 0;
+  cursor: pointer;
+}
+
+.sponsor-banner-filter {
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 12px 14px;
+  border-left: 1px solid rgba(255,255,255,0.15);
+  cursor: pointer;
+
+  ion-icon {
+    font-size: 20px;
+    opacity: 0.5;
+    transition: opacity 0.2s;
+
+    &.active {
+      opacity: 1;
+      color: #FFD779;
+    }
+  }
+}
+
+.sponsor-banner-logo {
+  width: 36px;
+  height: 36px;
+  object-fit: contain;
+  background: #fff;
+  border-radius: 8px;
+  padding: 4px;
+  flex-shrink: 0;
+}
+
+.sponsor-banner-icon {
+  font-size: 28px;
+  flex-shrink: 0;
+  opacity: 0.8;
+
+  &.warning {
+    color: #fff;
+    opacity: 1;
+  }
+}
+
+.sponsor-banner-text {
+  flex: 1;
+  min-width: 0;
+
+  strong {
+    display: block;
+    font-size: 0.95rem;
+    font-weight: 600;
+  }
+
+  span {
+    font-size: 0.75rem;
+    opacity: 0.7;
+  }
+}
+
+.sponsor-banner-chevron {
+  font-size: 20px;
+  opacity: 0.5;
+}
+
+/* Permission card */
+.permission-card {
+  margin: 16px;
+  border-radius: 12px;
+
+  h3 {
+    margin: 0 0 8px;
+    font-weight: 700;
+  }
+
+  code {
+    background: rgba(255,255,255,0.2);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 0.8rem;
+  }
+}
+
+
+/* Empty state */
+.empty-state {
+  display: flex;
   flex-direction: column;
-  height: 100%;
+  align-items: center;
+  justify-content: center;
+  padding: 64px 32px;
+  text-align: center;
+
+  .empty-icon {
+    font-size: 56px;
+    color: var(--ion-color-step-300, #ccc);
+    margin-bottom: 16px;
+  }
+
+  h3 {
+    margin: 0 0 6px;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--ion-text-color);
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--ion-color-medium);
+  }
 }
 
-.footer-button {
-  position: absolute;
-}
-.footer-toolbar {
-  padding-top: 1em;
-  padding-bottom: 1em;
+/* Scan list */
+.scan-list {
+  padding-top: 0;
 }
 
-.header-info {
-  font-size: .6em;
-  padding-bottom: .5em;
+.scan-item {
+  --padding-start: 12px;
+  --inner-padding-end: 4px;
+}
+
+.scan-status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-inline-end: 12px;
+  background: var(--ion-color-medium);
+
+  &.captured { background: var(--ion-color-success); }
+  &.pending { background: var(--ion-color-warning); }
+  &.failed { background: var(--ion-color-danger); }
+}
+
+.scan-name {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.scan-sponsor {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 0.7rem;
+  color: #5833E9;
+  font-weight: 500;
+  margin: 2px 0 0;
+
+  ion-icon { font-size: 0.7rem; }
+}
+
+.scan-time {
+  font-size: 0.75rem;
+  color: var(--ion-color-medium);
+  margin: 2px 0 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.scan-badge {
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  padding: 1px 6px;
+  border-radius: 4px;
+
+  &.pending {
+    background: rgba(var(--ion-color-warning-rgb), 0.15);
+    color: var(--ion-color-warning-shade);
+  }
+
+  &.failed {
+    background: rgba(var(--ion-color-danger-rgb), 0.15);
+    color: var(--ion-color-danger);
+  }
+}
+
+/* Last scan bar */
+.last-scan-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px;
+  background: var(--ion-color-step-50, #f8f8f8);
+  border-top: 1px solid var(--ion-color-step-100, #eee);
+}
+
+.last-scan-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  ion-icon { font-size: 22px; }
+}
+
+.last-scan-name {
+  font-size: 0.95rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.last-scan-spinner {
+  width: 16px;
+  height: 16px;
+}
+
+/* Action buttons */
+.scanner-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 4px 16px 8px;
+
+  .scan-btn-main {
+    --border-radius: 14px;
+    font-weight: 700;
+    font-size: 1rem;
+    letter-spacing: 0.02em;
+  }
+}
+
+.scan-note-icon {
+  font-size: 18px;
 }

--- a/src/app/pages/map/map.ts
+++ b/src/app/pages/map/map.ts
@@ -9,6 +9,7 @@ import { PyConAPI } from '../../providers/pycon-api';
 import { UserData } from '../../providers/user-data';
 import { LiveUpdateService } from '../../providers/live-update.service';
 import { LeadNoteModalComponent } from '../../lead-note-modal/lead-note-modal.component';
+import { environment } from '../../../environments/environment';
 
 
 @Component({
@@ -32,6 +33,8 @@ export class MapPage implements OnInit, OnDestroy {
   isStaffScanner: boolean = false;
   selectedSponsor: any = null;
   sponsorList: any[] = [];
+  isDev: boolean = !environment.production;
+  filterBySponsor: boolean = false;
 
   constructor(
     public confData: ConferenceData,
@@ -47,7 +50,15 @@ export class MapPage implements OnInit, OnDestroy {
   ) {}
 
   sortScans() {
-    return this.scan_presentation.sort(function(a, b) {
+    let scans = [...this.scan_presentation];
+    if (this.isStaffScanner && this.filterBySponsor && this.selectedSponsor) {
+      const filterName = this.selectedSponsor.name;
+      scans = scans.filter(s => {
+        const name = (s.sponsor_name || '').replace(/^"|"$/g, '');
+        return name === filterName;
+      });
+    }
+    return scans.sort(function(a, b) {
       var x = new Date(a.scanned_at);
       var y = new Date(b.scanned_at);
       return ((x > y) ? -1 : ((x < y) ? 1 : 0));
@@ -56,13 +67,19 @@ export class MapPage implements OnInit, OnDestroy {
 
   refresh_presentation = async () => {
     var allScans = [];
-    this.storage.forEach((value, key, index) => {
+    const selectedId = this.selectedSponsor ? String(this.selectedSponsor.id) : null;
+    const keys = await this.storage.keys();
+    for (const key of keys) {
+      const value = await this.storage.get(key);
+      if (!value) continue;
       if (key.startsWith("pending-scan-")) {
         allScans.push({
           "status": "pending",
           "scanned_at": value.scannedAt,
           "access_code": value.scanData.split(":")[0],
           "note": value.note,
+          "sponsor_name": value.sponsorName ? String(value.sponsorName).replace(/^"|"$/g, '') : null,
+          "sponsor_id": value.sponsorId || null,
         })
       } else if (key.startsWith("synced-scan-")) {
         allScans.push({
@@ -71,6 +88,8 @@ export class MapPage implements OnInit, OnDestroy {
           "access_code": value.scanData.split(":")[0],
           "first_name": value.data.first_name,
           "note": value.note,
+          "sponsor_name": value.sponsorName ? String(value.sponsorName).replace(/^"|"$/g, '') : null,
+          "sponsor_id": value.sponsorId || null,
         })
       } else if (key.startsWith("failed-scan-")) {
         allScans.push({
@@ -78,10 +97,17 @@ export class MapPage implements OnInit, OnDestroy {
           "scanned_at": value.scannedAt,
           "access_code": value.scanData.split(":")[0],
           "note": value.note,
+          "sponsor_name": value.sponsorName ? String(value.sponsorName).replace(/^"|"$/g, '') : null,
+          "sponsor_id": value.sponsorId || null,
         })
       }
-    });
+    }
     this.scan_presentation = allScans;
+    this.detectorRef.detectChanges();
+  }
+
+  toggleSponsorFilter() {
+    this.detectorRef.detectChanges();
   }
 
   openNoteModal = async (accessCode, scan) => {
@@ -233,6 +259,29 @@ export class MapPage implements OnInit, OnDestroy {
     this.content_visibility = '';
   }
 
+  async simulateScan() {
+    const fakeNames = [
+      'Guido van Rossum', 'Carol Willing', 'Brett Cannon', 'Mariatta Wijaya',
+      'Pablo Galindo', 'Dustin Ingram', 'Sumana Harihareswara', 'Ned Batchelder',
+      'Lynn Root', 'Russell Keith-Magee', 'Hynek Schlawack', 'Łukasz Langa',
+      'Deb Nicholson', 'Thomas Wouters', 'Barry Warsaw', 'Savannah Ostrowski',
+    ];
+    const name = fakeNames[Math.floor(Math.random() * fakeNames.length)];
+    const fakeCode = 'SIM' + Math.floor(Math.random() * 99999);
+    const scanDate = new Date();
+
+    const sponsorName = this.selectedSponsor?.name ? String(this.selectedSponsor.name).replace(/^"|"$/g, '') : null;
+    await this.storage.set('synced-scan-' + fakeCode, {
+      scanData: fakeCode + ':SIMULATED',
+      scannedAt: scanDate.toISOString(),
+      sponsorName: sponsorName,
+      sponsorId: this.selectedSponsor ? String(this.selectedSponsor.id) : null,
+      data: { first_name: name, captured: true, captured_date: scanDate.toISOString() },
+    });
+    this.refresh_presentation();
+    this.detectorRef.detectChanges();
+  }
+
   ionViewWillLeave() {
     this.stopScan();
   }
@@ -251,7 +300,15 @@ export class MapPage implements OnInit, OnDestroy {
     const hasDoorCheck = await this.userData.checkHasDoorCheck();
     if (!hasLeadRetrieval && hasDoorCheck) {
       this.isStaffScanner = true;
-      this.showSponsorSelector();
+      // Restore previously selected sponsor from storage
+      const savedSponsorId = await this.storage.get('staff-sponsor-id');
+      const savedSponsorName = await this.storage.get('staff-sponsor-name');
+      const savedSponsorLogo = await this.storage.get('staff-sponsor-logo');
+      if (savedSponsorId && savedSponsorName) {
+        this.selectedSponsor = { id: savedSponsorId, name: String(savedSponsorName).replace(/^"|"$/g, ''), logo_url: savedSponsorLogo || null };
+      } else {
+        this.showSponsorSelector();
+      }
     }
   }
 
@@ -328,6 +385,9 @@ export class MapPage implements OnInit, OnDestroy {
             if (sponsorId) {
               this.selectedSponsor = this.sponsorList.find(s => String(s.id) === sponsorId);
               this.pycon.setStaffSponsorId(sponsorId);
+              this.storage.set('staff-sponsor-name', this.selectedSponsor?.name || null);
+              this.storage.set('staff-sponsor-logo', this.selectedSponsor?.logo_url || null);
+              this.refresh_presentation();
             }
           }
         }

--- a/src/app/pages/schedule/schedule.html
+++ b/src/app/pages/schedule/schedule.html
@@ -94,9 +94,31 @@
     </ion-item-group>
   </ion-list>
 
-  <ion-list-header [hidden]="hasData">
-    Schedule not loaded, if this persists check your network.
-  </ion-list-header>
+  <div class="error-state" [hidden]="hasData">
+    <div class="error-graphic">
+      <svg viewBox="0 0 110 110" class="python-logo-error" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <linearGradient id="pyGradA" x1="0" y1="0" x2="1" y2="0.5">
+            <stop offset="0%" stop-color="#3B3EA9"/>
+            <stop offset="100%" stop-color="#5833E9"/>
+          </linearGradient>
+          <linearGradient id="pyGradB" x1="0" y1="0.5" x2="1" y2="1">
+            <stop offset="0%" stop-color="#FFD779"/>
+            <stop offset="100%" stop-color="#D47454"/>
+          </linearGradient>
+        </defs>
+        <path fill="url(#pyGradA)" d="M54.9 0C41.6 0 29.1 2.4 29.1 13.1V22h26.4v3.3H18C10.5 25.3.5 30 .5 43.6S9 62 18 62h7.6v-13c0-8.7 7.5-16.4 18-16.4h25.9c8 0 14.4-6.6 14.4-14.5V13.1C84 5.4 73.5 0 54.9 0zM40 7.3c3 0 5.4 2.5 5.4 5.5s-2.4 5.4-5.4 5.4-5.4-2.4-5.4-5.4 2.4-5.5 5.4-5.5z"/>
+        <path fill="url(#pyGradB)" d="M55.1 110c13.3 0 25.8-2.4 25.8-13.1V88H54.5v-3.3h37.5c7.5 0 17.5-4.7 17.5-18.3S101 48 92 48h-7.6v13c0 8.7-7.5 16.4-18 16.4H40.5c-8 0-14.4 6.6-14.4 14.5v5c0 7.7 10.5 13.1 29.1 13.1zM70 102.7c-3 0-5.4-2.5-5.4-5.5s2.4-5.4 5.4-5.4 5.4 2.4 5.4 5.4-2.4 5.5-5.4 5.5z"/>
+      </svg>
+      <ion-icon name="cloud-offline-outline" class="error-cloud-icon"></ion-icon>
+    </div>
+    <h2 class="error-title">Couldn't load schedule</h2>
+    <p class="error-message">Check your network connection and try again. The schedule needs an internet connection to load for the first time.</p>
+    <ion-button fill="outline" (click)="reloadSchedule()" class="error-retry-btn">
+      <ion-icon slot="start" name="refresh-outline"></ion-icon>
+      Try Again
+    </ion-button>
+  </div>
 
   <div *ngIf="todayIndex !== null" slot="fixed" class="jump-now-wrapper">
     <button class="jump-now-btn" [class.collapsed]="jumpBtnCollapsed" (click)="jumpToNow()">

--- a/src/app/pages/schedule/schedule.scss
+++ b/src/app/pages/schedule/schedule.scss
@@ -228,3 +228,58 @@ $tracks: (
     cursor: default;
   }
 }
+
+/*
+ * Error state — schedule not loaded
+ */
+.error-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 48px 32px;
+  min-height: 50vh;
+}
+
+.error-graphic {
+  position: relative;
+  margin-bottom: 24px;
+
+  .python-logo-error {
+    width: 100px;
+    height: 100px;
+    opacity: 0.15;
+  }
+
+  .error-cloud-icon {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 48px;
+    color: #3B3EA9;
+  }
+}
+
+.error-title {
+  font-size: 1.3rem;
+  font-weight: 700;
+  margin: 0 0 8px;
+  color: var(--ion-text-color);
+}
+
+.error-message {
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--ion-color-medium);
+  margin: 0 0 24px;
+  max-width: 300px;
+}
+
+.error-retry-btn {
+  --border-radius: 12px;
+  --border-color: #3B3EA9;
+  --color: #3B3EA9;
+  font-weight: 600;
+}

--- a/src/app/pages/tabs-page/tabs-page-routing.module.ts
+++ b/src/app/pages/tabs-page/tabs-page-routing.module.ts
@@ -227,6 +227,15 @@ const routes: Routes = [
         loadChildren: () => import('../login/login.module').then(m => m.LoginModule)
       },
       {
+        path: 'dev-tools',
+        children: [
+          {
+            path: '',
+            loadChildren: () => import('../dev-tools/dev-tools.module').then(m => m.DevToolsPageModule)
+          }
+        ]
+      },
+      {
         path: '',
         redirectTo: '/app/tabs/schedule',
         pathMatch: 'full'

--- a/src/app/providers/pycon-api.ts
+++ b/src/app/providers/pycon-api.ts
@@ -386,9 +386,11 @@ export class PyConAPI {
       return;
     } else {
       const scanDate = new Date();
+      const sponsorId = await this.storage.get('staff-sponsor-id');
+      const sponsorName = await this.storage.get('staff-sponsor-name');
       return this.storage.set(
         'pending-scan-' + accessCode,
-        {scanData: scanData, scannedAt: scanDate.toISOString()}
+        {scanData: scanData, scannedAt: scanDate.toISOString(), sponsorId: sponsorId, sponsorName: sponsorName}
       ).then(() => {
         console.log('Scanned ' + accessCode);
         this.syncScan(accessCode);

--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -1,7 +1,7 @@
 export const environment = {
   name: 'development',
   production: false,
-  baseUrl: 'http://localhost:8000',
+  baseUrl: 'http://127.0.0.1:8000',
   storageKey: '__pycon_us_mobile_development_2026',
   timezone: 'America/Los_Angeles',
   utcOffset: -7,


### PR DESCRIPTION
## Summary
- **Lead Scanner redesign** — branded header, sponsor banner with logo + filter funnel, clean scan list with status dots and sponsor badges, tappable rows for notes, empty state, full-width action buttons
- **Dev Tools page** — dev-only page for clearing scan data, invalidating cache, nuking storage, dumping to console. Sidebar link at top (dev mode only)
- **Schedule error state** — Python logo watermark, cloud-offline icon, friendly message, "Try Again" button
- **Dev env fix** — baseUrl localhost -> 127.0.0.1

## Test plan
- [x] Lead Scanner page renders cleanly for staff (sponsor banner, filter)
- [x] Lead Scanner page renders cleanly for sponsor reps (no banner)
- [x] Scan rows open notes on tap
- [x] Filter funnel toggles sponsor filtering
- [x] Dev Tools page accessible in dev mode only
- [x] Schedule error state shows Python logo design

🤖 Generated with [Claude Code](https://claude.com/claude-code)