### PR TITLE
Show account page and logout when logged in without a nickname

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -170,6 +170,13 @@
             </ion-item>
           </ion-menu-toggle>
 
+          <ion-menu-toggle *ngIf="loggedIn" autoHide="false">
+            <ion-item button detail="false" (click)="logout()">
+              <ion-icon slot="start" name="log-out-outline" color="danger"></ion-icon>
+              <ion-label color="danger">Logout</ion-label>
+            </ion-item>
+          </ion-menu-toggle>
+
           <ion-item>
             <ion-icon slot="start" name="moon-outline"></ion-icon>
             <ion-label>Dark Mode</ion-label>

--- a/src/app/pages/account/account.html
+++ b/src/app/pages/account/account.html
@@ -9,13 +9,13 @@
 </ion-header>
 
 <ion-content scrollEvents="true" (ionScroll)="onScroll($event)">
-  <div *ngIf="nickname" class="account-hero">
+  <div *ngIf="loggedIn" class="account-hero">
     <ion-icon name="person-circle" class="account-hero-icon"></ion-icon>
-    <h1>{{nickname}}</h1>
-    <p><code>{{email}}</code></p>
+    <h1>{{ nickname || email || 'Account' }}</h1>
+    <p *ngIf="nickname && email"><code>{{email}}</code></p>
   </div>
 
-  <div *ngIf="nickname" class="account-actions">
+  <div *ngIf="loggedIn" class="account-actions">
     <ion-button *ngIf="isSpeaker" expand="block" color="tertiary" (click)="openSpeakerDiscord()">
       <ion-icon slot="start" name="logo-discord"></ion-icon>
       Speaker Discord

--- a/src/app/pages/account/account.ts
+++ b/src/app/pages/account/account.ts
@@ -20,6 +20,7 @@ export class AccountPage implements OnInit, AfterViewInit {
   showTitle = false;
   email: string;
   nickname: string;
+  loggedIn = false;
   isSpeaker: boolean = false;
 
   constructor(
@@ -43,6 +44,9 @@ export class AccountPage implements OnInit, AfterViewInit {
     this.getEmail();
     this.getNickname();
     this.checkIsSpeaker();
+    this.userData.isLoggedIn().then((loggedIn) => {
+      this.loggedIn = loggedIn;
+    });
   }
 
   getEmail() {
@@ -53,8 +57,12 @@ export class AccountPage implements OnInit, AfterViewInit {
 
   getNickname() {
     this.userData.getNickname().then((nickname) => {
-      if (nickname === null) {
-        this.router.navigate(['/app/tabs/login'], { replaceUrl: true });
+      if (!nickname) {
+        this.userData.isLoggedIn().then((loggedIn) => {
+          if (!loggedIn) {
+            this.router.navigate(['/app/tabs/login'], { replaceUrl: true });
+          }
+        });
       }
       this.nickname = nickname;
     });


### PR DESCRIPTION
## Summary

- Gate the account hero and action block on \`loggedIn\` instead of \`nickname\` so a user with no nickname still lands on their account page instead of being bounced back to \`/login\`.
- Add a Logout item in the side menu that shows whenever \`loggedIn\` is true.
- Fall back to email (or "Account") for the displayed name when no nickname is set, and hide the email sub-line in that case.

## Test plan

- [x] Log in as a user **with** a nickname → account page shows nickname + email, Logout appears in menu
- [ ] Log in as a user **without** a nickname → account page shows email (or "Account") and does not redirect to login; Logout appears in menu
- [x] Logged out → account page still redirects to \`/login\`; Logout menu item is hidden
- [x] Tap Logout → user is signed out and navigation reflects the logged-out state