### PR TITLE
Redesign Informational schedule row with centered notice treatment

### DIFF
--- a/src/app/pages/schedule/schedule.html
+++ b/src/app/pages/schedule/schedule.html
@@ -63,34 +63,50 @@
         </ion-label>
       </ion-item-divider>
 
-      <ion-item-sliding *ngFor="let session of group.sessions | sessionOrder" #slidingItem [attr.track]="session.track | lowercase" [hidden]="session.hide">
-        <ion-item [color]="session?.color? session.color : ''" [routerLink]="session.listRender? '/app/tabs/tracks/' + session.section: '/app/tabs/schedule/session/'+session.id">
-          <ion-label>
-            <h3>
-              <ion-icon *ngIf="session.favorite" slot="icon-only" name="star"></ion-icon>
-              {{session.name}}
-            </h3>
-            <span class="track-badge" [attr.data-track]="session.track | lowercase">{{session.track | trackName}}</span>
-            <span *ngIf="session.isSpanish" class="track-badge spanish-badge">En Español</span>
-            <span *ngIf="session.preRegistered" class="track-badge prereg-badge">Pre-registration required</span>
-            <p class="session-meta">
-              <span class="meta-item"><ion-icon name="time-outline"></ion-icon> {{session.timeStart}}<span *ngIf="session.timeStart !== session.timeEnd"> – {{session.timeEnd}}</span></span>
-              <span *ngIf="session.location" class="meta-item"><ion-icon name="location-outline"></ion-icon> {{session.location}}</span>
-            </p>
-            <p *ngIf="session?.speakerNames?.length" class="session-speakers">
-              <ion-icon name="person-outline"></ion-icon> {{session.speakerNames.join(', ')}}
-            </p>
-          </ion-label>
-        </ion-item>
-        <ion-item-options>
-          <ion-item-option color="favorite" (click)="addFavorite(slidingItem, session)" *ngIf="!session.favorite">
-            Favorite
-          </ion-item-option>
-          <ion-item-option color="danger" (click)="removeFavorite(slidingItem, session, 'Remove Favorite')" *ngIf="session.favorite">
-            Remove
-          </ion-item-option>
-        </ion-item-options>
-      </ion-item-sliding>
+      <ng-container *ngFor="let session of group.sessions | sessionOrder">
+        <a *ngIf="session.track === 'Informational'"
+           class="informational-notice"
+           [hidden]="session.hide"
+           [routerLink]="session.listRender ? '/app/tabs/tracks/' + session.section : '/app/tabs/schedule/session/' + session.id">
+          <h3 class="notice-title">
+            <ion-icon name="information-circle-outline" class="notice-icon" aria-hidden="true"></ion-icon>
+            <span class="notice-name">{{session.name}}</span>
+          </h3>
+          <p class="notice-meta">
+            <span class="meta-item"><ion-icon name="time-outline"></ion-icon> {{session.timeStart}}<span *ngIf="session.timeStart !== session.timeEnd"> – {{session.timeEnd}}</span></span>
+            <span *ngIf="session.location" class="meta-item"><ion-icon name="location-outline"></ion-icon> {{session.location}}</span>
+          </p>
+        </a>
+
+        <ion-item-sliding *ngIf="session.track !== 'Informational'" #slidingItem [attr.track]="session.track | lowercase" [hidden]="session.hide">
+          <ion-item [color]="session?.color? session.color : ''" [routerLink]="session.listRender? '/app/tabs/tracks/' + session.section: '/app/tabs/schedule/session/'+session.id">
+            <ion-label>
+              <h3>
+                <ion-icon *ngIf="session.favorite" slot="icon-only" name="star"></ion-icon>
+                {{session.name}}
+              </h3>
+              <span class="track-badge" [attr.data-track]="session.track | lowercase">{{session.track | trackName}}</span>
+              <span *ngIf="session.isSpanish" class="track-badge spanish-badge">En Español</span>
+              <span *ngIf="session.preRegistered" class="track-badge prereg-badge">Pre-registration required</span>
+              <p class="session-meta">
+                <span class="meta-item"><ion-icon name="time-outline"></ion-icon> {{session.timeStart}}<span *ngIf="session.timeStart !== session.timeEnd"> – {{session.timeEnd}}</span></span>
+                <span *ngIf="session.location" class="meta-item"><ion-icon name="location-outline"></ion-icon> {{session.location}}</span>
+              </p>
+              <p *ngIf="session?.speakerNames?.length" class="session-speakers">
+                <ion-icon name="person-outline"></ion-icon> {{session.speakerNames.join(', ')}}
+              </p>
+            </ion-label>
+          </ion-item>
+          <ion-item-options>
+            <ion-item-option color="favorite" (click)="addFavorite(slidingItem, session)" *ngIf="!session.favorite">
+              Favorite
+            </ion-item-option>
+            <ion-item-option color="danger" (click)="removeFavorite(slidingItem, session, 'Remove Favorite')" *ngIf="session.favorite">
+              Remove
+            </ion-item-option>
+          </ion-item-options>
+        </ion-item-sliding>
+      </ng-container>
     </ion-item-group>
   </ion-list>
 

--- a/src/app/pages/schedule/schedule.scss
+++ b/src/app/pages/schedule/schedule.scss
@@ -283,3 +283,75 @@ $tracks: (
   --color: #3B3EA9;
   font-weight: 600;
 }
+
+/*
+ * Informational notice row — replaces the gray "Informational" track item
+ * for announcements like "Swag Pickup Closes". Subtle theme-aware tint
+ * using --pycon-accent (purple in light, pink in dark). Centered,
+ * icon replaces the old "Informational" track-badge text.
+ */
+.informational-notice {
+  --notice-accent: var(--pycon-accent, #680579);
+  --notice-surface: var(--ion-item-background, var(--ion-background-color, #ffffff));
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 12px 16px;
+  text-align: center;
+  background: color-mix(in srgb, var(--notice-accent) 8%, var(--notice-surface));
+  color: var(--ion-text-color, inherit);
+  text-decoration: none;
+  transition: background 180ms ease-out;
+
+  .notice-title {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 600;
+    line-height: 1.3;
+  }
+
+  .notice-icon {
+    flex-shrink: 0;
+    font-size: 1.1em;
+    color: var(--notice-accent);
+  }
+
+  .notice-name {
+    min-width: 0;
+  }
+
+  .notice-meta {
+    display: inline-flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75em;
+    margin: 0;
+    font-size: 0.78rem;
+    opacity: 0.72;
+
+    .meta-item {
+      display: inline-flex;
+      align-items: center;
+      gap: 3px;
+    }
+
+    ion-icon {
+      font-size: 0.95em;
+    }
+  }
+
+  &:active {
+    background: color-mix(in srgb, var(--notice-accent) 14%, var(--notice-surface));
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--notice-accent);
+    outline-offset: -2px;
+  }
+}


### PR DESCRIPTION
## Summary

- Replaces the flat gray \"Informational\" track-item for announcements like \"Swag Pickup Closes\" with a centered, tinted notice row on the schedule.
- Drops the \"Informational\" track-badge text in favor of an inline information icon.
- Uses the existing \`--pycon-accent\` token (purple in light, pink in dark) so the row reads as branded in both themes without needing a per-theme layout branch.
- Row stays compact so multiple notices stack cleanly on a day (e.g. Sat 8:00 am with three back-to-back notices) without overwhelming the list.

Before → After: the row that used to read \"Swag Pickup Closes / Informational / 1:30 pm\" on a dark-gray bar now reads \"ⓘ  Swag Pickup Closes / 🕐 1:30 pm\" centered on a soft brand-tinted bar.

## Test plan

- [ ] Light mode: informational rows show a soft purple tint, icon + title centered on one line, time centered beneath
- [ ] Dark mode: informational rows show a soft pink tint, same layout
- [ ] Stacked notices (multiple back-to-back, e.g. Registration Desk Opens + Open Spaces Rooms Open + Expo Hall Opens on the same day) look consistent — icons align, rows feel like a rhythm not a billboard
- [ ] Non-informational sessions render unchanged
- [ ] Tapping a notice still navigates to its detail page
- [ ] \`prefers-reduced-motion\` still works (transition is a simple bg fade only)