### PR TITLE
Show active-filter state and quick-clear in schedule header

### DIFF
--- a/src/app/pages/schedule/schedule.html
+++ b/src/app/pages/schedule/schedule.html
@@ -13,8 +13,11 @@
       <ion-button (click)="toggleFavorites()" class="header-action">
         <ion-icon slot="icon-only" [name]="segment === 'favorites' ? 'star' : 'star-outline'"></ion-icon>
       </ion-button>
-      <ion-button (click)="presentFilter()" class="header-action">
-        <ion-icon slot="icon-only" name="funnel-outline"></ion-icon>
+      <ion-button *ngIf="excludeTracks.length" (click)="clearFilters()" class="header-action filters-active" aria-label="Clear filters">
+        <ion-icon slot="icon-only" name="close-circle"></ion-icon>
+      </ion-button>
+      <ion-button (click)="presentFilter()" class="header-action" [class.filters-active]="excludeTracks.length">
+        <ion-icon slot="icon-only" [name]="excludeTracks.length ? 'funnel' : 'funnel-outline'"></ion-icon>
       </ion-button>
     </ion-buttons>
   </ion-toolbar>

--- a/src/app/pages/schedule/schedule.scss
+++ b/src/app/pages/schedule/schedule.scss
@@ -77,6 +77,10 @@ $tracks: (
   &:active {
     --color: #680579;
   }
+
+  &.filters-active {
+    --color: #DD04D2;
+  }
 }
 
 .search-toolbar {

--- a/src/app/pages/schedule/schedule.ts
+++ b/src/app/pages/schedule/schedule.ts
@@ -244,6 +244,12 @@ export class SchedulePage implements OnInit, OnDestroy {
     }, 500); // ms delay
   }
 
+  clearFilters() {
+    this.excludeTracks = [];
+    this.user.setScheduleFilters([]);
+    this.updateSchedule();
+  }
+
   async presentFilter() {
     const modal = await this.modalCtrl.create({
       component: ScheduleFilterPage,


### PR DESCRIPTION
## Summary

- When track filters are active (\`excludeTracks\` non-empty), the funnel icon in the schedule header switches from outline → filled and turns PyCon 2026 pink (#DD04D2).
- A \`close-circle\` button appears before the funnel; tap clears all filter state (in-memory, storage, schedule refresh) in one shot.
- No header change at all when no filters are active.

Addresses the \"I have everything unselected except one track and I can't tell filters are on\" confusion + \"I can't quickly reset filters\" friction.

## Test plan

- [ ] No filters applied → header looks identical to before (outline funnel, gray)
- [ ] Open filter modal, exclude a track, confirm → funnel fills + goes pink, close-circle button appears
- [ ] Tap close-circle button → all filters cleared, icons return to default, schedule shows all tracks again
- [ ] Re-open the app → cleared state persists (storage was updated)
- [ ] Reopen filter modal → all tracks shown as included