### PR TITLE
Clamp job listing role titles to 2 lines

### DIFF
--- a/src/app/pages/job-listings/job-listings.page.scss
+++ b/src/app/pages/job-listings/job-listings.page.scss
@@ -127,4 +127,9 @@ ion-title {
 
 .role-title {
   font-size: 0.9rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  overflow-wrap: anywhere;
 }


### PR DESCRIPTION
## Summary

For sponsors whose listing text is prose without extractable \"Title | URL\" pairs (SerpApi, marimo, etc.), \`parseRoles()\` falls back to emitting the whole blob as a single pseudo-role. The title then overflowed the card with no truncation (shown previously as 12+ lines of body copy squished into a list-item slot).

Add \`-webkit-line-clamp: 2\` on \`.role-title\` with ellipsis. Normal short titles are a single line and are unaffected.

## Test plan

- [ ] Short titles (e.g. HRT — \"Research Engineer\") render unchanged on one line
- [ ] Fallback prose titles (SerpApi, marimo) clip at 2 lines with ellipsis