### PR TITLE
Render every speaker for co-hosted keynote sessions

### DIFF
--- a/src/app/pages/session-detail/session-detail.html
+++ b/src/app/pages/session-detail/session-detail.html
@@ -42,11 +42,11 @@
     </div>
 
     <div class="session-body">
-      <div *ngIf="keynoteData" class="keynote-speaker-card">
-        <img [src]="keynoteData.photo" [alt]="keynoteData.name" class="keynote-photo">
+      <div *ngFor="let keynote of keynoteData" class="keynote-speaker-card">
+        <img [src]="keynote.photo" [alt]="keynote.name" class="keynote-photo">
         <div class="keynote-info">
-          <h3>{{keynoteData.name}}</h3>
-          <p>{{keynoteData.bio}}</p>
+          <h3>{{keynote.name}}</h3>
+          <p>{{keynote.bio}}</p>
         </div>
       </div>
 

--- a/src/app/pages/session-detail/session-detail.ts
+++ b/src/app/pages/session-detail/session-detail.ts
@@ -18,7 +18,7 @@ export class SessionDetailPage {
   isFavorite = false;
   isOpenSpace = false;
   isKeynote = false;
-  keynoteData: any = null;
+  keynoteData: any[] = [];
   defaultHref = '';
 
   private keynoteSpeakers: Record<string, any> = {
@@ -63,15 +63,14 @@ export class SessionDetailPage {
         this.isOpenSpace = this.session?.tracks?.includes('open-space');
         this.isKeynote = this.session?.tracks?.includes('keynote') || this.session?.track === 'Keynote';
 
-        // Enrich keynote sessions with speaker photo/bio
+        // Enrich keynote sessions with speaker photo/bio. Collect every
+        // matching speaker so co-hosted keynotes (e.g. "Rachell Calhoun &
+        // Tim Schilling") render all speakers, not just the first match.
         if (this.isKeynote) {
-          const sessionName = this.session?.name || '';
-          for (const [name, data] of Object.entries(this.keynoteSpeakers)) {
-            if (sessionName.toLowerCase().includes(name.toLowerCase())) {
-              this.keynoteData = { name, ...data };
-              break;
-            }
-          }
+          const sessionName = (this.session?.name || '').toLowerCase();
+          this.keynoteData = Object.entries(this.keynoteSpeakers)
+            .filter(([name]) => sessionName.includes(name.toLowerCase()))
+            .map(([name, data]) => ({ name, ...data }));
         }
 
         this.isFavorite = this.userProvider.hasFavorite(


### PR DESCRIPTION
## Summary

Session detail pages for co-hosted keynote sessions (e.g. \"Rachell Calhoun & Tim Schilling\") were only showing one speaker. The enrichment loop stopped at the first matching keynote speaker in \`keynoteSpeakers\`:

```ts
for (const [name, data] of Object.entries(this.keynoteSpeakers)) {
  if (sessionName.toLowerCase().includes(name.toLowerCase())) {
    this.keynoteData = { name, ...data };
    break;  // <- only the first hit
  }
}
```

For the Sun 3:15 pm slot, iteration hit Tim Schilling first, set \`keynoteData\` to Tim, and broke — Rachell Calhoun never made it to the template.

## Fix

- \`keynoteData\` is now an array of every matching keynote speaker.
- Template \`ngFor\`s the speaker card so all matches render.

## Test plan

- [ ] Rachell Calhoun & Tim Schilling session detail — both speaker cards render
- [ ] Single-speaker keynote sessions (Lin Qiao, amanda casari, Pablo Galindo Salgado) still render one card
- [ ] Non-keynote sessions unchanged