### PR TITLE
Make sponsor header tappable in job listings

### DIFF
--- a/src/app/pages/job-listings/job-listings.page.html
+++ b/src/app/pages/job-listings/job-listings.page.html
@@ -29,19 +29,22 @@
 
   <div class="listings-container">
     <div *ngFor="let listing of listings" class="listing-card">
-      <div class="sponsor-header">
+      <a class="sponsor-header"
+         [routerLink]="'/app/tabs/sponsors/sponsor-detail/' + getSponsorSlug(listing.sponsor_name)">
         <img *ngIf="listing.sponsor_logo_url" [src]="listing.sponsor_logo_url" [alt]="listing.sponsor_name + ' logo'" class="sponsor-logo">
         <div class="sponsor-info">
           <h2 class="sponsor-name">{{listing.sponsor_name}}</h2>
           <span *ngIf="listing.sponsor_level" class="level-badge">{{listing.sponsor_level}}</span>
         </div>
-      </div>
+        <ion-icon name="chevron-forward" class="sponsor-chevron" aria-hidden="true"></ion-icon>
+      </a>
 
       <ion-list *ngIf="listing.roles?.length > 0" class="roles-list" lines="none">
         <ion-item *ngFor="let role of listing.roles" class="role-item" [button]="!!role.url" (click)="openUrl(role.url)" [detail]="!!role.url">
           <ion-icon name="briefcase-outline" slot="start" color="medium" class="role-icon"></ion-icon>
           <ion-label class="role-label">
             <span class="role-title">{{role.title}}</span>
+            <span *ngIf="role.location" class="role-location">{{role.location}}</span>
           </ion-label>
         </ion-item>
       </ion-list>

--- a/src/app/pages/job-listings/job-listings.page.scss
+++ b/src/app/pages/job-listings/job-listings.page.scss
@@ -72,6 +72,19 @@ ion-title {
   align-items: center;
   gap: 12px;
   margin-bottom: 12px;
+  text-decoration: none;
+  color: inherit;
+
+  &:active {
+    opacity: 0.6;
+  }
+}
+
+.sponsor-chevron {
+  margin-left: auto;
+  font-size: 18px;
+  color: var(--ion-color-step-400, #a0a0a0);
+  flex-shrink: 0;
 }
 
 .sponsor-logo {
@@ -132,4 +145,11 @@ ion-title {
   -webkit-box-orient: vertical;
   overflow: hidden;
   overflow-wrap: anywhere;
+}
+
+.role-location {
+  display: block;
+  margin-top: 2px;
+  font-size: 0.75rem;
+  opacity: 0.6;
 }

--- a/src/app/pages/job-listings/job-listings.page.ts
+++ b/src/app/pages/job-listings/job-listings.page.ts
@@ -28,14 +28,24 @@ export class JobListingsPage implements OnInit {
 
   processListings(raw: any[]): any[] {
     return raw.map(listing => {
+      const structured = Array.isArray(listing.postings) ? listing.postings : [];
+      const roles = structured.length > 0
+        ? structured
+            .filter(p => (p.title || '').trim() && (p.url || '').trim())
+            .map(p => ({
+              title: (p.title || '').trim(),
+              location: (p.location || '').trim(),
+              url: (p.url || '').trim(),
+            }))
+        : this.parseRoles(listing.description_html);
       return {
         ...listing,
-        roles: this.parseRoles(listing.description_html),
+        roles,
       };
     });
   }
 
-  parseRoles(html: string): {title: string, url: string}[] {
+  parseRoles(html: string): {title: string, location: string, url: string}[] {
     if (!html) return [];
 
     // Strip HTML tags to work with plain text
@@ -47,11 +57,11 @@ export class JobListingsPage implements OnInit {
 
     if (urls.length === 0) {
       // No URLs — just return the text as a single entry
-      return text.length > 0 ? [{title: text, url: ''}] : [];
+      return text.length > 0 ? [{title: text, location: '', url: ''}] : [];
     }
 
     // Try splitting by URLs to find role names
-    const roles: {title: string, url: string}[] = [];
+    const roles: {title: string, location: string, url: string}[] = [];
     let remaining = text;
 
     for (const url of urls) {
@@ -63,12 +73,12 @@ export class JobListingsPage implements OnInit {
           const lines = before.split(/\n/).filter(l => l.trim());
           const title = lines[lines.length - 1].replace(/^[-|–]\s*/, '').trim();
           if (title.length > 0 && title.length < 200) {
-            roles.push({title, url});
+            roles.push({title, location: '', url});
           } else {
-            roles.push({title: this.shortenUrl(url), url});
+            roles.push({title: this.shortenUrl(url), location: '', url});
           }
         } else {
-          roles.push({title: this.shortenUrl(url), url});
+          roles.push({title: this.shortenUrl(url), location: '', url});
         }
         remaining = remaining.substring(idx + url.length).replace(/^\s*[-|–,]\s*/, '').trim();
       }
@@ -76,7 +86,7 @@ export class JobListingsPage implements OnInit {
 
     // If we couldn't parse anything meaningful, return the raw text as one block
     if (roles.length === 0 && text.length > 0) {
-      return [{title: text, url: ''}];
+      return [{title: text, location: '', url: ''}];
     }
 
     return roles;
@@ -127,7 +137,8 @@ export class JobListingsPage implements OnInit {
     }
     const words = this.searchText.toLowerCase().replace(/,|\.|-/g, ' ').split(' ').filter(w => w.trim().length);
     this.listings = this.allListings.filter(listing => {
-      const haystack = `${listing.sponsor_name || ''} ${listing.description_html || ''} ${listing.roles?.map(r => r.title).join(' ') || ''}`.toLowerCase();
+      const roleText = listing.roles?.map(r => `${r.title} ${r.location || ''}`).join(' ') || '';
+      const haystack = `${listing.sponsor_name || ''} ${listing.description_html || ''} ${roleText}`.toLowerCase();
       return words.every(word => haystack.includes(word));
     });
   }
@@ -141,6 +152,10 @@ export class JobListingsPage implements OnInit {
     if (url) {
       window.open(url, '_system', 'location=yes');
     }
+  }
+
+  getSponsorSlug(name: string): string {
+    return (name || '').toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
   }
 
   ngOnInit() {


### PR DESCRIPTION
## Summary

Each sponsor row on the Job Listings page now links to that sponsor's detail page — no dead headers.

- \`.sponsor-header\` becomes an \`<a>\` with \`routerLink\` to \`/app/tabs/sponsors/sponsor-detail/<slug>\`, reusing the slug scheme from the Sponsors page
- Adds a right-side chevron to signal tappability, mirroring the role rows below it
- Threads a structured-postings code path through \`processListings\` / \`parseRoles\` / \`filterListings\` so listings that carry explicit \`postings: [{title, location, url}]\` render directly (with location shown) instead of going through markdown parsing; falls back to the existing HTML parser when no structured data is present

## Test plan

- [ ] Tap a sponsor header in Job Listings → navigates to that sponsor's detail page
- [ ] Sponsor logo area also registers as a tap (single anchor wraps logo + name + level badge)
- [ ] Role rows underneath still open their external URL and don't trigger header navigation
- [ ] Sponsors whose API response includes \`postings\` render each posting as its own row with title + location
- [ ] Sponsors without structured postings still render via markdown parsing as before