### PR TITLE
Bump @capacitor-mlkit/barcode-scanning to 7.5.0 for 16 KB page-size support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ionic-conference-app",
-  "version": "0.0.0",
+  "version": "26.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ionic-conference-app",
-      "version": "0.0.0",
+      "version": "26.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -17,7 +17,7 @@
         "@angular/platform-browser-dynamic": "^17.3.12",
         "@angular/router": "^17.3.12",
         "@angular/service-worker": "^17.3.12",
-        "@capacitor-mlkit/barcode-scanning": "^7.0.0",
+        "@capacitor-mlkit/barcode-scanning": "^7.5.0",
         "@capacitor/android": "^7.0.0",
         "@capacitor/app": "^7.0.0",
         "@capacitor/core": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@angular/platform-browser-dynamic": "^17.3.12",
     "@angular/router": "^17.3.12",
     "@angular/service-worker": "^17.3.12",
-    "@capacitor-mlkit/barcode-scanning": "^7.0.0",
+    "@capacitor-mlkit/barcode-scanning": "^7.5.0",
     "@capacitor/android": "^7.0.0",
     "@capacitor/app": "^7.0.0",
     "@capacitor/core": "^7.0.0",


### PR DESCRIPTION
## Summary

Play Console rejected `versionCode 260003` with:

> Your app does not support 16 KB memory page sizes.

Inspected the AAB's native libs with `objdump -p`:

| File | arm64-v8a | x86_64 |
|------|-----------|--------|
| `libbarhopper_v3.so` (MLKit Barcode) | ✅ 2^14 (16 KB) | ✅ 2^14 (16 KB) |
| `libimage_processing_util_jni.so` (CameraX) | ❌ 2^12 (4 KB) | ❌ 2^12 (4 KB) |

The blocker is CameraX's JNI lib, which is pulled in transitively by `@capacitor-mlkit/barcode-scanning`. Only 64-bit ABIs matter — Play Store only enforces 16 KB on those.

`@capacitor-mlkit/barcode-scanning` 7.5.0 pulls in a CameraX release (≥ 1.4.0-beta02) that ships 16 KB-aligned native libraries. Bump stays on v7 since v8 requires Capacitor 8.

Ruled out:
- `packagingOptions.jniLibs.useLegacyPackaging = false` — that affects APK/AAB *packaging*, not the ELF `p_align` inside the `.so`. Google's 16 KB check reads the compiled-in alignment.
- Pinning `cameraxVersion` in `variables.gradle` — unnecessary if the plugin bump pulls in a compliant CameraX; keep as a fallback if the rebuilt `.so` is still 4 KB aligned.

## Test plan

- [ ] `npm install` on a clean checkout — `package-lock.json` resolves `@capacitor-mlkit/barcode-scanning` at 7.5.0
- [ ] `npx cap sync android`
- [ ] Build the release bundle
- [ ] Extract AAB, run `objdump -p base/lib/arm64-v8a/libimage_processing_util_jni.so` → LOAD alignments should show `align 2**14`
- [ ] Same for `base/lib/x86_64/libimage_processing_util_jni.so`
- [ ] Scan a barcode on a test device to confirm the CameraX bump didn't break the scanner flow
- [ ] Re-upload to Play Console under the next versionCode (260004+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)