### PR TITLE
fit sponsor logos and text

### DIFF
--- a/src/app/pages/tabs-page/tabs-page.html
+++ b/src/app/pages/tabs-page/tabs-page.html
@@ -1,7 +1,7 @@
 <ion-tabs>
   <ion-tab-bar class="bannerSponsor bannerSponsorHidden" slot="bottom" *ngFor="let BannerSponsor of sponsors">
-    <img src="{{BannerSponsor.logo_url}}" style="height: 75%; padding-left: 1em; padding-right: 1em;">
-    <span style="padding-left: 1em; font-size: smaller;"> {{BannerSponsor.name}} is a {{BannerSponsor.level}}<br> Sponsor of PyCon US 2026</span>
+    <img class="bannerSponsor-logo" src="{{BannerSponsor.logo_url}}">
+    <span class="bannerSponsor-text">{{BannerSponsor.name}} is a {{BannerSponsor.level}}<br> Sponsor of PyCon US 2026</span>
   </ion-tab-bar>
 
   <ion-tab-bar slot="bottom" class="pycon-tab-bar">

--- a/src/app/pages/tabs-page/tabs-page.scss
+++ b/src/app/pages/tabs-page/tabs-page.scss
@@ -11,11 +11,25 @@
 }
 .bannerSponsor {
   padding-bottom: 0;
+  gap: 1em;
+  padding-left: 1em;
+  padding-right: 1em;
 }
-.bannerSponsor img {
+.bannerSponsor-logo {
   background-color: white;
   border-radius: .25em;
   padding: .25em;
+  max-width: 110px;
+  max-height: 44px;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+.bannerSponsor-text {
+  font-size: smaller;
+  flex: 1;
+  min-width: 0;
 }
 
 .staff-tools-sheet {


### PR DESCRIPTION
Before sponsor text, if the sponsor name was long, would overflow out of the panel