### PR TITLE
fix(scanners): hide swag in Door Check and sessions in Swag Pickup

### DIFF
--- a/src/app/pages/door-check/door-check.page.ts
+++ b/src/app/pages/door-check/door-check.page.ts
@@ -331,8 +331,18 @@ export class DoorCheckPage implements OnInit, OnDestroy {
     this.syncAllPending();
     this.pycon.fetchCheckInProducts().then((data) => {
       data.subscribe(redeemable => {
-        this.redeemable_products = redeemable?.redeemable_products;
-        this.redeemable_categories = redeemable?.redeemable_categories;
+        // /check_in/redeemable/ returns the union of every redeemable
+        // category (sessions + swag) and CategorySerializer omits
+        // render_type, so we have to discriminate by name. Door check
+        // is for sessions/events only — drop the merch categories and
+        // any products hanging off them. Long-term fix: expose
+        // render_type (==10 for presentations) on the API.
+        const categories = (redeemable?.redeemable_categories ?? [])
+          .filter(c => !/shirt|swag/i.test(c?.name ?? ''));
+        const keepIds = new Set(categories.map(c => c.id));
+        this.redeemable_categories = categories;
+        this.redeemable_products = (redeemable?.redeemable_products ?? [])
+          .filter(p => keepIds.has(p.category));
       })
     })
   }

--- a/src/app/pages/t-shirt-redemption/t-shirt-redemption.page.ts
+++ b/src/app/pages/t-shirt-redemption/t-shirt-redemption.page.ts
@@ -214,8 +214,18 @@ export class TShirtRedemptionPage implements OnInit, OnDestroy {
     this.ios = this.config.get('mode') === `ios`;
     this.pycon.fetchCheckInProducts().then((data) => {
       data.subscribe(redeemable => {
-        this.redeemable_products = redeemable?.redeemable_products;
-        this.redeemable_categories = redeemable?.redeemable_categories;
+        // /check_in/redeemable/ returns the union of every redeemable
+        // category (sessions + swag) and CategorySerializer omits
+        // render_type, so we have to discriminate by name. Swag pickup
+        // only redeems merch — keep T-Shirt categories (and any
+        // future "swag-*" naming) and drop the rest. Long-term fix:
+        // expose render_type on the API.
+        const categories = (redeemable?.redeemable_categories ?? [])
+          .filter(c => /shirt|swag/i.test(c?.name ?? ''));
+        const keepIds = new Set(categories.map(c => c.id));
+        this.redeemable_categories = categories;
+        this.redeemable_products = (redeemable?.redeemable_products ?? [])
+          .filter(p => keepIds.has(p.category));
       })
     })
   }


### PR DESCRIPTION
## Summary
- Door Check was showing T-Shirt categories and Swag Pickup was showing Tutorials / Sponsor Presentations / Summits — both pages call \`/check_in/redeemable/\` which returns the **union** of every redeemable category and \`CategorySerializer\` only emits \`(id, name)\`, so the client had nothing to discriminate on.
- Filter the response client-side by category name in each page's \`ngOnInit\`:
  - **Door Check** keeps categories *not* matching \`/shirt|swag/i\`.
  - **Swag Pickup** keeps categories *matching* \`/shirt|swag/i\`.
- Products are also filtered to those whose surviving category is in the kept set, so "All sessions in this category" + the search list don't leak through.

A comment in each \`ngOnInit\` points at the proper long-term fix (expose \`render_type\` on \`CategorySerializer\` in \`pycon-site\` and filter on \`render_type === 10\` for presentations).

## Effect — given \`pycon-site/fixtures/inventory.json\`

| Page | Categories shown after fix |
|---|---|
| Door Check | Tutorials, Sponsor Presentations, Job Fair Add-On, Summits and Events, PyLadies Auction |
| Swag Pickup | Conference T-Shirts, Charlas T-Shirts, PyLadies T-Shirts |

## Test plan
- [ ] \`make serve\`, sign in as someone with check-in permissions.
- [ ] Open **Door Check**: chips contain only sessions/events (no shirts). Pick **Tutorials** → product list is tutorial sessions only.
- [ ] Open **Swag Pickup**: chips contain only T-Shirt categories. Pick **Conference T-Shirts** → product list is shirt sizes only.
- [ ] Scan a real attendee QR on each page; redemption flow still works (server-side \`?mode=…\` filter is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)