### PR TITLE
fix(rooms): normalize Hall AB to Expo Hall AB for plenary slots

### DIFF
--- a/src/app/providers/conference-data.ts
+++ b/src/app/providers/conference-data.ts
@@ -355,6 +355,16 @@ export class ConferenceData {
           sessionLocation = roomMatch[1];
           slot.name = slot.name.replace(roomMatch[0], '').trim();
         }
+        // Normalize bare "Hall AB"/"Hall C" to canonical "Expo Hall …" so
+        // plenaries that name the venue as "Hall AB" (Opening Reception,
+        // Posters, etc.) land in the same room bucket as sponsor booths /
+        // posters / lunches that all live under the "Expo Hall AB" name.
+        // Without this, Opening Reception ends up in a separate "Hall AB"
+        // room with no other context, and the Expo Hall AB room view looks
+        // like the reception isn't scheduled at all.
+        if (sessionLocation && /^Hall\s/i.test(sessionLocation)) {
+          sessionLocation = `Expo ${sessionLocation}`;
+        }
         // Strip track prefix like "Keynote — ", "Keynote: " from name since badge shows it
         const trackPrefix = new RegExp('^' + slot.kind.replace(/-/g, '[- ]') + '\\s*[—:\\-–]\\s*', 'i');
         slot.name = slot.name.replace(trackPrefix, '').trim();


### PR DESCRIPTION
## Summary
Opening Reception (and Posters / Lunch / similar) on plenary-kind slots have their venue tagged in the title as \`(Hall AB)\`. After parens-extraction they end up with \`location=\"Hall AB\"\`, which became its own stub room — meanwhile sponsor booths and the collapsed break/poster path all normalize to \`\"Expo Hall AB\"\`. Result: the user-facing \"Expo Hall AB\" room view didn't include Opening Reception on Thursday night.

This applies the same \`Hall …\` → \`Expo Hall …\` rewrite (already used by the collapsed-groups path at line 286) to plenary-kind slots so everything funnels into one room bucket.

## Test plan
- [ ] Rooms tab → Expo Hall AB shows Thursday Opening Reception (and Friday/Saturday/Sunday Lunch (Hall AB), Posters (Hall AB), etc).
- [ ] No phantom "Hall AB" room remains in the rooms list.
- [ ] Session detail location label still reads cleanly (\"Expo Hall AB\" instead of \"Hall AB\").

🤖 Generated with [Claude Code](https://claude.com/claude-code)