### PR TITLE
fix(schedule): don't collapse same-named breaks across the day

### DIFF
--- a/src/app/providers/conference-data.ts
+++ b/src/app/providers/conference-data.ts
@@ -261,7 +261,12 @@ export class ConferenceData {
     data.schedule.filter((s: any) => collapseKinds.includes(s.kind)).forEach((slot: any) => {
       const day = new Date(slot.start).toLocaleDateString('en-us', {timeZone: environment.timezone, weekday: 'short'});
       const slotName = markdownToTxt(slot.name);
-      const key = `${slot.kind}-${day}-${slotName}`;
+      // Include start time in the key so morning and afternoon "Break"
+      // entries don't collapse into a single 10:30-4:30 row that spans
+      // the lunches and afternoon talks. Per-room same-start slots
+      // (e.g. all the 13:00 Lunch (Hall AB) entries across talk rooms)
+      // still share a key and merge correctly.
+      const key = `${slot.kind}-${day}-${slotName}-${slot.start}`;
       if (!collapsedGroups.has(key)) {
         // Rename lunchtime breaks
         let name = slot.kind === 'poster' ? 'Posters' : markdownToTxt(slot.name);


### PR DESCRIPTION
## Summary
Friday's morning Break (10:30-11:00) and afternoon Break (16:00-16:30) were collapsing into one row spanning 10:30-16:30 in the schedule and room views. Same key bug for any other day with multiple same-named Break / Lunch / Poster slots.

The collapsedGroups key was \`kind-day-slotName\`. Adding \`-start\` to the key keeps the intended use case (multiple per-room slots that share a start time merge into one row) while preventing cross-time collapsing.

## Why it matters
Room 201B's Friday view shows "Break 10:30am-4:30pm" instead of two separate breaks at 10:30-11 and 16:00-16:30. The merged row also obscures the actual 10:30 morning break duration.

## Test plan
- [ ] Friday Room 201B detail: shows two separate Break entries (10:30-11:00, 16:00-16:30), not one merged 10:30-16:30 row.
- [ ] Friday talk rooms: morning Break and afternoon Break each render at their actual times.
- [ ] Per-room lunches still collapse: Friday Lunch (Hall AB) renders as ONE row across Grand Ballrooms / 103ABC / 104AB / 104C (since they all start at 13:00), not five separate ones.
- [ ] Saturday and Sunday breaks: same expectation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)