### PR TITLE
fix(schedule): break headline location reads venue, not first audience room

### DIFF
--- a/src/app/providers/conference-data.ts
+++ b/src/app/providers/conference-data.ts
@@ -348,6 +348,7 @@ export class ConferenceData {
       // For plenary-like slots, extract room from parentheses in the title
       // and strip redundant track prefix (e.g., "Keynote — " since the badge shows it)
       var sessionLocation = slot.room;
+      var displayLocationOverride: string | null = null;
       const plenaryKinds = ['plenary', 'keynote', 'lightning-talks', 'event'];
       if (plenaryKinds.includes(slot.kind)) {
         const roomMatch = slot.name.match(/\s*\(([^)]+)\)\s*$/);
@@ -358,6 +359,26 @@ export class ConferenceData {
         // Strip track prefix like "Keynote — ", "Keynote: " from name since badge shows it
         const trackPrefix = new RegExp('^' + slot.kind.replace(/-/g, '[- ]') + '\\s*[—:\\-–]\\s*', 'i');
         slot.name = slot.name.replace(trackPrefix, '').trim();
+      } else if (slot.kind === 'break') {
+        // Break slots fan out to every audience room (Grand Ballrooms, 103ABC,
+        // 104AB, etc. — attendees in each room see "break time"). But the
+        // headline location displayed in the schedule timeline should be the
+        // single venue where the break service actually happens, e.g.
+        // "Expo Hall AB" (coffee/snacks). Pull that out of the parenthesized
+        // suffix in the slot name when present, so a slot with content
+        // "Break (Expo Hall AB)" / "Coffee (Hall AB)" displays the right
+        // place — but leave session.location (the comma-joined room list)
+        // untouched so the per-room fanout still registers the slot in
+        // every room's room-detail view.
+        const roomMatch = slot.name.match(/\s*\(([^)]+)\)\s*$/);
+        if (roomMatch) {
+          let displayRoom = roomMatch[1].trim();
+          if (/^Hall\s/i.test(displayRoom)) {
+            displayRoom = `Expo ${displayRoom}`;
+          }
+          displayLocationOverride = displayRoom;
+          slot.name = slot.name.replace(roomMatch[0], '').trim();
+        }
       }
 
       // Flag Spanish-language sessions and strip "En Español" from title
@@ -395,7 +416,7 @@ export class ConferenceData {
         }
       }
 
-      var session = {
+      var session: any = {
           "name": slot.name,
           "color": this.slotColors[slot.kind],
           "preRegistered": slot.preRegistered,
@@ -403,6 +424,7 @@ export class ConferenceData {
           "listRender": slot.list_render,
           "section": slot.section,
           "location": sessionLocation,
+          "displayLocationOverride": displayLocationOverride,
           "description": slot.description,
           "speakers": [],
           "speakerNames": slot.authors,
@@ -677,7 +699,12 @@ export class ConferenceData {
       // fanout above relies on it). For the schedule timeline we show
       // only the first room — wide multi-room labels for breaks/lunch
       // wrapped onto multiple lines and looked terrible.
-      session.displayLocation = links.length > 0 ? links[0].name : (session.location || '');
+      // displayLocationOverride wins when set (break slots use it to
+      // surface the venue where service actually happens — e.g. coffee
+      // is in Expo Hall AB even though the break is registered against
+      // every audience room).
+      session.displayLocation = session.displayLocationOverride
+        || (links.length > 0 ? links[0].name : (session.location || ''));
     });
     roomMap.forEach((room: any) => {
       room.sessions.sort(


### PR DESCRIPTION
## Summary
Friday morning Break headline showed "Room 201B" and Saturday morning Break showed "Room 103ABC" because the schedule timeline picks the first room from the comma-joined fan-out. Coffee/snacks are actually in the Expo Hall AB. The DB-side fix already labels the slot \`Break (Expo Hall AB)\`; this PR pulls that parenthesized venue out for the headline.

## How
- Added a \`displayLocationOverride\` per-session string. For \`kind=break\` slots, parses the trailing \`(...)\` from the slot name (with the same \`Hall …\` → \`Expo Hall …\` normalization the plenary path uses) and stores it.
- After room fanout, \`displayLocation\` prefers the override when present, else falls back to the first room as before.
- \`session.location\` (the comma-joined fanout source) is unchanged, so the break still appears in every audience room's room-detail.

## Test plan
- [ ] Friday timeline 10:30am Break: headline reads "Expo Hall AB", not "Room 201B".
- [ ] Saturday timeline 10:05am Break: headline reads "Expo Hall AB", not "Room 103ABC".
- [ ] Each audience room (Grand Ballroom A, 103ABC, 104AB, 201B, etc.) still has the Break entry in its room-detail view.
- [ ] Sat afternoon Break (15:45-16:15) still shows whatever room it's labeled with (or first audience room if untagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)