### PR TITLE
fix(schedule): don't split poster collapse on start time (regression from #289)

### DIFF
--- a/src/app/providers/conference-data.ts
+++ b/src/app/providers/conference-data.ts
@@ -261,12 +261,19 @@ export class ConferenceData {
     data.schedule.filter((s: any) => collapseKinds.includes(s.kind)).forEach((slot: any) => {
       const day = new Date(slot.start).toLocaleDateString('en-us', {timeZone: environment.timezone, weekday: 'short'});
       const slotName = markdownToTxt(slot.name);
-      // Include start time in the key so morning and afternoon "Break"
-      // entries don't collapse into a single 10:30-4:30 row that spans
-      // the lunches and afternoon talks. Per-room same-start slots
-      // (e.g. all the 13:00 Lunch (Hall AB) entries across talk rooms)
-      // still share a key and merge correctly.
-      const key = `${slot.kind}-${day}-${slotName}-${slot.start}`;
+      // Include start time in the key for break slots so morning and
+      // afternoon "Break" entries don't collapse into a single 10:30-4:30
+      // row spanning lunches and afternoon talks. Per-room same-start
+      // breaks/lunches still merge correctly because they share start.
+      //
+      // POSTERS are different — every individual poster slot in the API
+      // is a 5-minute kind="poster" entry with name="Posters", and we
+      // intentionally fold the entire daily poster session into ONE row.
+      // Adding start to the key here would split them back into 50+
+      // 5-minute rows, which is the regression PR #289 introduced.
+      // So: only add start for breaks.
+      const startKey = slot.kind === 'break' ? `-${slot.start}` : '';
+      const key = `${slot.kind}-${day}-${slotName}${startKey}`;
       if (!collapsedGroups.has(key)) {
         // Rename lunchtime breaks
         let name = slot.kind === 'poster' ? 'Posters' : markdownToTxt(slot.name);


### PR DESCRIPTION
## Summary
PR #289 added \`slot.start\` to the collapsedGroups key to stop morning+afternoon Break slots merging into one 10:30-4:30 row. Side effect: every 5-minute \`kind=\"poster\"\` slot got its own key too, so the daily poster session exploded into 50+ rows on the Sunday schedule.

Only append start to the key for \`kind=\"break\"\`. Posters keep the original \`kind-day-name\` key and collapse to one row again.

## Test plan
- [ ] Sun schedule: poster session shows as ONE "Posters" row at the start time, not 50 individual 5-minute rows.
- [ ] Sat / Wed posters (if any): same.
- [ ] Friday's morning Break and afternoon Break still render as TWO separate rows (the #289 fix stays intact for breaks).
- [ ] Per-room same-start lunches still merge into one row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)