### PR TITLE
feat(ui): add scroll-to-top FAB to the Schedule page

### DIFF
--- a/src/app/pages/schedule/schedule.html
+++ b/src/app/pages/schedule/schedule.html
@@ -22,7 +22,7 @@
   </ion-toolbar>
 </ion-header>
 
-<ion-content fullscreen="true">
+<ion-content fullscreen="true" #pageContent scrollEvents="true">
   <ion-refresher slot="fixed" (ionRefresh)="handleRefresh($event)">
     <ion-refresher-content></ion-refresher-content>
   </ion-refresher>
@@ -144,5 +144,7 @@
       <span class="jump-now-label">Jump to Now</span>
     </button>
   </div>
+
+  <app-scroll-to-top [content]="pageContent"></app-scroll-to-top>
 
 </ion-content>

--- a/src/app/pages/schedule/schedule.module.ts
+++ b/src/app/pages/schedule/schedule.module.ts
@@ -8,6 +8,7 @@ import { ScheduleFilterPage } from '../schedule-filter/schedule-filter';
 import { SchedulePageRoutingModule } from './schedule-routing.module';
 import { SessionOrderPipe } from '../../pipes/session-order.pipe';
 import { PipesModule } from '../../pipes/pipes.module';
+import { ScrollToTopModule } from '../../scroll-to-top/scroll-to-top.module';
 
 @NgModule({
     imports: [
@@ -15,7 +16,8 @@ import { PipesModule } from '../../pipes/pipes.module';
         FormsModule,
         IonicModule,
         SchedulePageRoutingModule,
-        PipesModule
+        PipesModule,
+        ScrollToTopModule
     ],
     declarations: [
         SchedulePage,


### PR DESCRIPTION
Depends on #291. Adds the same scroll-to-top FAB to the Schedule timeline tab — that page was skipped in #291 because its IonContent lacked scrollEvents=true.

Coexists with the existing 'Jump to Now' pill (FAB is bottom-end, pill is bottom-start).